### PR TITLE
Domain specific language for Behavior tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nom = "7.1.1"
 serde = "1.0.136"
 serde_yaml = "0.8.23"
 symbol = "0.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 serde = "1.0.136"
 serde_yaml = "0.8.23"
+symbol = "0.1.9"
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -27,7 +27,11 @@ impl PrintArmNode {
 }
 
 impl BehaviorNode for PrintArmNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        ctx: &mut Context,
+    ) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
         if let Some(arm) = ctx.get::<Arm>(self.arm_sym) {
@@ -54,7 +58,7 @@ impl PrintBodyNode {
 }
 
 impl BehaviorNode for PrintBodyNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+    fn tick(&mut self, _: &mut dyn FnMut(&dyn std::any::Any), ctx: &mut Context) -> BehaviorResult {
         if let Some(body) = ctx.get::<Body>(self.body_sym) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
@@ -112,7 +116,8 @@ fn main() -> anyhow::Result<()> {
 
     let mut root =
         load(&tree_source, &registry).map_err(|e| anyhow::format_err!("parse error: {e}"))?;
-    println!("root: {:?}", root.tick(&mut ctx));
+    let mut null = |_: &dyn std::any::Any| ();
+    println!("root: {:?}", root.tick(&mut null, &mut ctx));
 
     //     let result = main.tick(&mut ctx);
 

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -70,35 +70,27 @@ impl BehaviorNode for PrintBodyNode {
     }
 }
 
-struct PrintArmNodeConstructor;
-
-impl Constructor for PrintArmNodeConstructor {
-    fn build(&self) -> Box<dyn BehaviorNode> {
-        Box::new(PrintArmNode::new())
-    }
+fn print_arm_node() -> Box<dyn BehaviorNode> {
+    Box::new(PrintArmNode::new())
 }
 
-struct PrintBodyNodeConstructor;
+fn print_body_node() -> Box<dyn BehaviorNode> {
+    let start = std::time::Instant::now();
 
-impl Constructor for PrintBodyNodeConstructor {
-    fn build(&self) -> Box<dyn BehaviorNode> {
-        let start = std::time::Instant::now();
+    let ret = PrintBodyNode::new();
 
-        let ret = PrintBodyNode::new();
+    eprintln!(
+        "construct time: {}",
+        start.elapsed().as_nanos() as f64 * 1e-9
+    );
 
-        eprintln!(
-            "construct time: {}",
-            start.elapsed().as_nanos() as f64 * 1e-9
-        );
-
-        Box::new(ret)
-    }
+    Box::new(ret)
 }
 
 fn main() -> anyhow::Result<()> {
     let mut registry = Registry::default();
-    registry.register("PrintArmNode", Box::new(PrintArmNodeConstructor));
-    registry.register("PrintBodyNode", Box::new(PrintBodyNodeConstructor));
+    registry.register("PrintArmNode", Box::new(print_arm_node));
+    registry.register("PrintBodyNode", Box::new(print_body_node));
     let file = String::from_utf8(fs::read("test.yaml")?).unwrap();
     let mut trees = load_yaml(&file, &registry)?;
 

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -1,4 +1,6 @@
-use ::behavior_tree_lite::{load, parse_file, BehaviorNode, BehaviorResult, Context, Registry};
+use ::behavior_tree_lite::{
+    load, parse_file, BehaviorCallback, BehaviorNode, BehaviorResult, Context, Registry,
+};
 
 use std::fs;
 use symbol::Symbol;
@@ -27,11 +29,7 @@ impl PrintArmNode {
 }
 
 impl BehaviorNode for PrintArmNode {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
         if let Some(arm) = ctx.get::<Arm>(self.arm_sym) {
@@ -54,11 +52,7 @@ impl PrintStringNode {
 }
 
 impl BehaviorNode for PrintStringNode {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         if let Some(s) = ctx.get::<String>(self.input) {
             println!("PrintStringNode: {}", s);
         } else {
@@ -85,7 +79,7 @@ impl PrintBodyNode {
 }
 
 impl BehaviorNode for PrintBodyNode {
-    fn tick(&mut self, _: &mut dyn FnMut(&dyn std::any::Any), ctx: &mut Context) -> BehaviorResult {
+    fn tick(&mut self, _: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         if let Some(body) = ctx.get::<Body>(self.body_sym) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
@@ -147,7 +141,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut root =
         load(&tree_source, &registry).map_err(|e| anyhow::format_err!("parse error: {e}"))?;
-    let mut null = |_: &dyn std::any::Any| ();
+    let mut null = |_: &dyn std::any::Any| -> Option<Box<dyn std::any::Any>> { None };
     println!("root: {:?}", root.tick(&mut null, &mut ctx));
 
     //     let result = main.tick(&mut ctx);

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -41,6 +41,33 @@ impl BehaviorNode for PrintArmNode {
     }
 }
 
+struct PrintStringNode {
+    input: Symbol,
+}
+
+impl PrintStringNode {
+    fn new() -> Self {
+        Self {
+            input: "input".into(),
+        }
+    }
+}
+
+impl BehaviorNode for PrintStringNode {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        ctx: &mut Context,
+    ) -> BehaviorResult {
+        if let Some(s) = ctx.get::<String>(self.input) {
+            println!("PrintStringNode: {}", s);
+        } else {
+            println!("PrintStringNode: didn't get string");
+        }
+        BehaviorResult::Success
+    }
+}
+
 struct PrintBodyNode {
     body_sym: Symbol,
     left_arm_sym: Symbol,
@@ -94,6 +121,10 @@ fn main() -> anyhow::Result<()> {
     let mut registry = Registry::default();
     registry.register("PrintArmNode", Box::new(print_arm_node));
     registry.register("PrintBodyNode", Box::new(print_body_node));
+    registry.register(
+        "PrintStringNode",
+        Box::new(|| Box::new(PrintStringNode::new())),
+    );
 
     let file = String::from_utf8(fs::read("test.txt")?).unwrap();
 

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -1,6 +1,5 @@
-use ::behavior_tree_lite::{
-    load_yaml, BehaviorNode, BehaviorResult, Constructor, Context, Registry,
-};
+use ::behavior_tree_lite::{parse_file, BehaviorNode, BehaviorResult, Context, Registry};
+
 use std::fs;
 use symbol::Symbol;
 
@@ -91,26 +90,30 @@ fn main() -> anyhow::Result<()> {
     let mut registry = Registry::default();
     registry.register("PrintArmNode", Box::new(print_arm_node));
     registry.register("PrintBodyNode", Box::new(print_body_node));
-    let file = String::from_utf8(fs::read("test.yaml")?).unwrap();
-    let mut trees = load_yaml(&file, &registry)?;
 
-    if let Some(main) = trees.get_mut("main") {
-        let body = Body {
-            left_arm: Arm {
-                name: "left_arm".to_string(),
-            },
-            right_arm: Arm {
-                name: "right_arm".to_string(),
-            },
-        };
+    let file = String::from_utf8(fs::read("test.txt")?).unwrap();
 
-        let mut ctx = Context::default();
-        ctx.set("body".into(), body);
+    let (_, tree_source) =
+        parse_file(&file).map_err(|e| anyhow::format_err!("parse error: {e:?}"))?;
+    println!("tree_source: {tree_source:?}");
 
-        let result = main.tick(&mut ctx);
+    // if let Some(main) = trees.get_mut("main") {
+    //     let body = Body {
+    //         left_arm: Arm {
+    //             name: "left_arm".to_string(),
+    //         },
+    //         right_arm: Arm {
+    //             name: "right_arm".to_string(),
+    //         },
+    //     };
 
-        eprintln!("result: {:?}", result);
-    }
+    //     let mut ctx = Context::default();
+    //     ctx.set("body".into(), body);
+
+    //     let result = main.tick(&mut ctx);
+
+    //     eprintln!("result: {:?}", result);
+    // }
 
     Ok(())
 }

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -15,13 +15,23 @@ struct Body {
     right_arm: Arm,
 }
 
-struct PrintArmNode;
+struct PrintArmNode {
+    arm_sym: Symbol,
+}
+
+impl PrintArmNode {
+    fn new() -> Self {
+        Self {
+            arm_sym: "arm".into(),
+        }
+    }
+}
 
 impl BehaviorNode for PrintArmNode {
     fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
-        if let Some(arm) = ctx.get::<Arm>(Symbol::from("arm")) {
+        if let Some(arm) = ctx.get::<Arm>(self.arm_sym) {
             println!("Got {}", arm.name);
         }
         BehaviorResult::Success
@@ -29,25 +39,29 @@ impl BehaviorNode for PrintArmNode {
 }
 
 struct PrintBodyNode {
+    body_sym: Symbol,
     left_arm_sym: Symbol,
+    right_arm_sym: Symbol,
 }
 
 impl PrintBodyNode {
     fn new() -> Self {
         Self {
+            body_sym: "body".into(),
             left_arm_sym: "left_arm".into(),
+            right_arm_sym: "right_arm".into(),
         }
     }
 }
 
 impl BehaviorNode for PrintBodyNode {
     fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
-        if let Some(body) = ctx.get::<Body>("body".into()) {
+        if let Some(body) = ctx.get::<Body>(self.body_sym) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
             println!("Got Body: {:?}", body);
-            ctx.set("left_arm".into(), left_arm);
-            ctx.set("right_arm".into(), right_arm);
+            ctx.set(self.left_arm_sym, left_arm);
+            ctx.set(self.right_arm_sym, right_arm);
             BehaviorResult::Success
         } else {
             println!("No body!");
@@ -60,7 +74,7 @@ struct PrintArmNodeConstructor;
 
 impl Constructor for PrintArmNodeConstructor {
     fn build(&self) -> Box<dyn BehaviorNode> {
-        Box::new(PrintArmNode)
+        Box::new(PrintArmNode::new())
     }
 }
 
@@ -99,7 +113,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let mut ctx = Context::default();
-        ctx.set("body", body);
+        ctx.set("body".into(), body);
 
         let result = main.tick(&mut ctx);
 

--- a/examples/from_file.rs
+++ b/examples/from_file.rs
@@ -1,4 +1,4 @@
-use ::behavior_tree_lite::{parse_file, BehaviorNode, BehaviorResult, Context, Registry};
+use ::behavior_tree_lite::{load, parse_file, BehaviorNode, BehaviorResult, Context, Registry};
 
 use std::fs;
 use symbol::Symbol;
@@ -95,20 +95,24 @@ fn main() -> anyhow::Result<()> {
 
     let (_, tree_source) =
         parse_file(&file).map_err(|e| anyhow::format_err!("parse error: {e:?}"))?;
-    println!("tree_source: {tree_source:?}");
+    println!("tree_source: {tree_source:#?}");
 
     // if let Some(main) = trees.get_mut("main") {
-    //     let body = Body {
-    //         left_arm: Arm {
-    //             name: "left_arm".to_string(),
-    //         },
-    //         right_arm: Arm {
-    //             name: "right_arm".to_string(),
-    //         },
-    //     };
+    let body = Body {
+        left_arm: Arm {
+            name: "left_arm".to_string(),
+        },
+        right_arm: Arm {
+            name: "right_arm".to_string(),
+        },
+    };
 
-    //     let mut ctx = Context::default();
-    //     ctx.set("body".into(), body);
+    let mut ctx = Context::default();
+    ctx.set("body".into(), body);
+
+    let mut root =
+        load(&tree_source, &registry).map_err(|e| anyhow::format_err!("parse error: {e}"))?;
+    println!("root: {:?}", root.tick(&mut ctx));
 
     //     let result = main.tick(&mut ctx);
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,5 @@
 use ::behavior_tree_lite::{hash_map, BehaviorNode, BehaviorResult, Context, SequenceNode};
+use ::symbol::Symbol;
 
 #[derive(Clone, Debug)]
 struct Arm {
@@ -17,7 +18,7 @@ impl BehaviorNode for PrintArmNode {
     fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
-        if let Some(arm) = ctx.get::<Arm>("arm") {
+        if let Some(arm) = ctx.get::<Arm>("arm".into()) {
             println!("Got {}", arm.name);
         }
         BehaviorResult::Success
@@ -28,12 +29,12 @@ struct PrintBodyNode;
 
 impl BehaviorNode for PrintBodyNode {
     fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
-        if let Some(body) = ctx.get::<Body>("body") {
+        if let Some(body) = ctx.get::<Body>(Symbol::from("body")) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
             println!("Got Body: {:?}", body);
-            ctx.set("left_arm", left_arm);
-            ctx.set("right_arm", right_arm);
+            ctx.set("left_arm".into(), left_arm);
+            ctx.set("right_arm".into(), right_arm);
             BehaviorResult::Success
         } else {
             BehaviorResult::Fail
@@ -52,7 +53,7 @@ fn main() {
     };
 
     let mut ctx = Context::default();
-    ctx.set("body", body);
+    ctx.set("body".into(), body);
 
     let mut root = SequenceNode::default();
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,5 +1,6 @@
 use ::behavior_tree_lite::{
-    hash_map, BehaviorNode, BehaviorResult, BlackboardValue, Context, SequenceNode,
+    hash_map, BehaviorCallback, BehaviorNode, BehaviorResult, BlackboardValue, Context,
+    SequenceNode,
 };
 use ::symbol::Symbol;
 
@@ -17,11 +18,7 @@ struct Body {
 struct PrintArmNode;
 
 impl BehaviorNode for PrintArmNode {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
         if let Some(arm) = ctx.get::<Arm>("arm".into()) {
@@ -34,11 +31,7 @@ impl BehaviorNode for PrintArmNode {
 struct PrintBodyNode;
 
 impl BehaviorNode for PrintBodyNode {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         if let Some(body) = ctx.get::<Body>(Symbol::from("body")) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
@@ -81,5 +74,5 @@ fn main() {
 
     root.add_child(Box::new(print_arms), hash_map!());
 
-    root.tick(&mut |_| (), &mut ctx);
+    root.tick(&mut |_| None, &mut ctx);
 }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,6 @@
-use ::behavior_tree_lite::{hash_map, BehaviorNode, BehaviorResult, Context, SequenceNode};
+use ::behavior_tree_lite::{
+    hash_map, BehaviorNode, BehaviorResult, BlackboardValue, Context, SequenceNode,
+};
 use ::symbol::Symbol;
 
 #[derive(Clone, Debug)]
@@ -68,8 +70,14 @@ fn main() {
     root.add_child(Box::new(PrintBodyNode), hash_map!());
 
     let mut print_arms = SequenceNode::default();
-    print_arms.add_child(Box::new(PrintArmNode), hash_map!("arm" => "left_arm"));
-    print_arms.add_child(Box::new(PrintArmNode), hash_map!("arm" => "right_arm"));
+    print_arms.add_child(
+        Box::new(PrintArmNode),
+        hash_map!("arm" => BlackboardValue::Ref("left_arm".into())),
+    );
+    print_arms.add_child(
+        Box::new(PrintArmNode),
+        hash_map!("arm" => BlackboardValue::Ref("right_arm".into())),
+    );
 
     root.add_child(Box::new(print_arms), hash_map!());
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -15,7 +15,11 @@ struct Body {
 struct PrintArmNode;
 
 impl BehaviorNode for PrintArmNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        ctx: &mut Context,
+    ) -> BehaviorResult {
         println!("Arm {:?}", ctx);
 
         if let Some(arm) = ctx.get::<Arm>("arm".into()) {
@@ -28,7 +32,11 @@ impl BehaviorNode for PrintArmNode {
 struct PrintBodyNode;
 
 impl BehaviorNode for PrintBodyNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        ctx: &mut Context,
+    ) -> BehaviorResult {
         if let Some(body) = ctx.get::<Body>(Symbol::from("body")) {
             let left_arm = body.left_arm.clone();
             let right_arm = body.right_arm.clone();
@@ -65,5 +73,5 @@ fn main() {
 
     root.add_child(Box::new(print_arms), hash_map!());
 
-    root.tick(&mut ctx);
+    root.tick(&mut |_| (), &mut ctx);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub use crate::parser::{
 pub enum BehaviorResult {
     Success,
     Fail,
+    /// The node should keep running in the next tick
+    Running,
 }
 
 #[derive(Debug)]
@@ -33,11 +35,11 @@ pub struct Context<'e, T: 'e = ()> {
 }
 
 impl<'e, T> Context<'e, T> {
-    pub fn new(env: &'e mut T) -> Self {
+    pub fn new(blackboard: HashMap<Symbol, Box<dyn Any>>) -> Self {
         Self {
-            blackboard: HashMap::new(),
+            blackboard,
             blackboard_map: HashMap::new(),
-            env: Some(env),
+            env: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use symbol::Symbol;
 
 pub use crate::nodes::{FallbackNode, SequenceNode};
 pub use crate::parser::{
-    load, load_yaml, node_def, parse_file, parse_nodes, Constructor, NodeDef, Registry,
+    boxify, load, load_yaml, node_def, parse_file, parse_nodes, Constructor, NodeDef, Registry,
 };
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ use std::collections::HashMap;
 use symbol::Symbol;
 
 pub use crate::nodes::{FallbackNode, SequenceNode};
-pub use crate::parser::{load_yaml, Constructor, Registry};
+pub use crate::parser::{
+    load_yaml, node_def, parse_file, parse_nodes, Constructor, NodeDef, Registry,
+};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum BehaviorResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use symbol::Symbol;
 
 pub use crate::nodes::{FallbackNode, SequenceNode};
 pub use crate::parser::{
-    load_yaml, node_def, parse_file, parse_nodes, Constructor, NodeDef, Registry,
+    load, load_yaml, node_def, parse_file, parse_nodes, Constructor, NodeDef, Registry,
 };
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,5 +1,6 @@
 use crate::{BehaviorNode, BehaviorNodeContainer, BehaviorResult, Context};
 use std::collections::HashMap;
+use symbol::Symbol;
 
 #[derive(Default)]
 pub struct SequenceNode {
@@ -18,7 +19,7 @@ impl BehaviorNode for SequenceNode {
         BehaviorResult::Success
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<String, String>) {
+    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,
@@ -43,7 +44,7 @@ impl BehaviorNode for FallbackNode {
         BehaviorResult::Fail
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<String, String>) {
+    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -2,13 +2,18 @@ use crate::{BehaviorNode, BehaviorNodeContainer, BehaviorResult, Context};
 use std::collections::HashMap;
 use symbol::Symbol;
 
-#[derive(Default)]
-pub struct SequenceNode {
-    children: Vec<BehaviorNodeContainer>,
+pub struct SequenceNode<E> {
+    children: Vec<BehaviorNodeContainer<E>>,
 }
 
-impl BehaviorNode for SequenceNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+impl<E> Default for SequenceNode<E> {
+    fn default() -> Self {
+        Self { children: vec![] }
+    }
+}
+
+impl<E> BehaviorNode<E> for SequenceNode<E> {
+    fn tick(&mut self, ctx: &mut Context<E>) -> BehaviorResult {
         for node in &mut self.children {
             std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
             if node.node.tick(ctx) == BehaviorResult::Fail {
@@ -19,7 +24,11 @@ impl BehaviorNode for SequenceNode {
         BehaviorResult::Success
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
+    fn add_child(
+        &mut self,
+        node: Box<dyn BehaviorNode<E>>,
+        blackboard_map: HashMap<Symbol, Symbol>,
+    ) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,
@@ -27,13 +36,18 @@ impl BehaviorNode for SequenceNode {
     }
 }
 
-#[derive(Default)]
-pub struct FallbackNode {
-    children: Vec<BehaviorNodeContainer>,
+pub struct FallbackNode<E> {
+    children: Vec<BehaviorNodeContainer<E>>,
 }
 
-impl BehaviorNode for FallbackNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+impl<E> Default for FallbackNode<E> {
+    fn default() -> Self {
+        Self { children: vec![] }
+    }
+}
+
+impl<E> BehaviorNode<E> for FallbackNode<E> {
+    fn tick(&mut self, ctx: &mut Context<E>) -> BehaviorResult {
         for node in &mut self.children {
             std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
             if node.node.tick(ctx) == BehaviorResult::Success {
@@ -44,7 +58,11 @@ impl BehaviorNode for FallbackNode {
         BehaviorResult::Fail
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
+    fn add_child(
+        &mut self,
+        node: Box<dyn BehaviorNode<E>>,
+        blackboard_map: HashMap<Symbol, Symbol>,
+    ) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,4 +1,7 @@
-use crate::{BBMap, BehaviorNode, BehaviorNodeContainer, BehaviorResult, BlackboardValue, Context};
+use crate::{
+    BBMap, BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult, BlackboardValue,
+    Context,
+};
 use std::collections::HashMap;
 use symbol::Symbol;
 
@@ -13,11 +16,7 @@ impl Default for SequenceNode {
 }
 
 impl BehaviorNode for SequenceNode {
-    fn tick(
-        &mut self,
-        arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         for node in &mut self.children {
             std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
             if node.node.tick(arg, ctx) == BehaviorResult::Fail {
@@ -48,11 +47,7 @@ impl Default for FallbackNode {
 }
 
 impl BehaviorNode for FallbackNode {
-    fn tick(
-        &mut self,
-        arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         for node in &mut self.children {
             std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
             if node.node.tick(arg, ctx) == BehaviorResult::Success {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,4 +1,4 @@
-use crate::{BehaviorNode, BehaviorNodeContainer, BehaviorResult, Context};
+use crate::{BBMap, BehaviorNode, BehaviorNodeContainer, BehaviorResult, BlackboardValue, Context};
 use std::collections::HashMap;
 use symbol::Symbol;
 
@@ -28,7 +28,7 @@ impl BehaviorNode for SequenceNode {
         BehaviorResult::Success
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
+    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: BBMap) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,
@@ -65,7 +65,7 @@ impl BehaviorNode for FallbackNode {
         BehaviorResult::Fail
     }
 
-    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: HashMap<Symbol, Symbol>) {
+    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: BBMap) {
         self.children.push(BehaviorNodeContainer {
             node,
             blackboard_map,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -24,6 +24,7 @@ impl BehaviorNode for SequenceNode {
                 std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
                 return BehaviorResult::Fail;
             }
+            std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
         }
         BehaviorResult::Success
     }
@@ -52,15 +53,13 @@ impl BehaviorNode for FallbackNode {
         arg: &mut dyn FnMut(&dyn std::any::Any),
         ctx: &mut Context,
     ) -> BehaviorResult {
-        let children = self.children.len();
-        for (i, node) in self.children.iter_mut().enumerate() {
-            println!("FallbackNode node child: {}/{}", i, children);
+        for node in &mut self.children {
             std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
             if node.node.tick(arg, ctx) == BehaviorResult::Success {
                 std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
                 return BehaviorResult::Success;
             }
-            println!("FallbackNode node failed: {}/{children}", i);
+            std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
         }
         BehaviorResult::Fail
     }

--- a/src/nodes/test.rs
+++ b/src/nodes/test.rs
@@ -1,0 +1,150 @@
+use super::*;
+
+struct Append<const V: bool = true>;
+
+impl<const V: bool> BehaviorNode for Append<V> {
+    fn tick(&mut self, arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
+        arg(&V);
+        BehaviorResult::Success
+    }
+}
+
+#[test]
+fn test_sequence() {
+    let mut res = vec![];
+
+    let mut append = |v: &dyn std::any::Any| {
+        res.push(*v.downcast_ref::<bool>().unwrap());
+        None
+    };
+
+    let mut tree = SequenceNode::default();
+    tree.add_child(Box::new(Append::<true>), BBMap::new());
+    tree.add_child(Box::new(Append::<false>), BBMap::new());
+
+    assert_eq!(
+        BehaviorResult::Success,
+        tree.tick(&mut append, &mut Context::default())
+    );
+
+    assert_eq!(res, vec![true, false]);
+
+    let mut tree = SequenceNode::default();
+    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new());
+    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new());
+
+    assert_eq!(
+        BehaviorResult::Fail,
+        tree.tick(&mut |_| None, &mut Context::default())
+    );
+}
+
+struct Suspend;
+
+impl BehaviorNode for Suspend {
+    fn tick(&mut self, _arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
+        BehaviorResult::Running
+    }
+}
+
+#[test]
+fn test_sequence_suspend() {
+    let mut res = vec![];
+
+    let mut tree = SequenceNode::default();
+    tree.add_child(Box::new(Append::<true>), BBMap::new());
+    tree.add_child(Box::new(Suspend), BBMap::new());
+    tree.add_child(Box::new(Append::<false>), BBMap::new());
+
+    assert_eq!(
+        tree.tick(
+            &mut |v: &dyn std::any::Any| {
+                res.push(*v.downcast_ref::<bool>().unwrap());
+                None
+            },
+            &mut Context::default(),
+        ),
+        BehaviorResult::Running
+    );
+
+    assert_eq!(res, vec![true]);
+
+    // Even ticking again won't invoke push(false)
+    tree.tick(
+        &mut |v: &dyn std::any::Any| {
+            res.push(*v.downcast_ref::<bool>().unwrap());
+            None
+        },
+        &mut Context::default(),
+    );
+
+    assert_eq!(res, vec![true]);
+}
+
+struct AppendAndFail<const V: bool = true>;
+
+impl<const V: bool> BehaviorNode for AppendAndFail<V> {
+    fn tick(&mut self, arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
+        arg(&V);
+        BehaviorResult::Fail
+    }
+}
+
+#[test]
+fn test_fallback() {
+    let mut res = vec![];
+
+    let mut append = |v: &dyn std::any::Any| {
+        res.push(*v.downcast_ref::<bool>().unwrap());
+        None
+    };
+
+    let mut tree = FallbackNode::default();
+    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new());
+    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new());
+
+    assert_eq!(
+        BehaviorResult::Fail,
+        tree.tick(&mut append, &mut Context::default())
+    );
+
+    assert_eq!(res, vec![true, false]);
+
+    let mut tree = SequenceNode::default();
+    tree.add_child(Box::new(Append::<true>), BBMap::new());
+    tree.add_child(Box::new(Append::<false>), BBMap::new());
+}
+
+#[test]
+fn test_fallback_suspend() {
+    let mut res = vec![];
+
+    let mut tree = FallbackNode::default();
+    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new());
+    tree.add_child(Box::new(Suspend), BBMap::new());
+    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new());
+
+    assert_eq!(
+        tree.tick(
+            &mut |v: &dyn std::any::Any| {
+                res.push(*v.downcast_ref::<bool>().unwrap());
+                None
+            },
+            &mut Context::default(),
+        ),
+        BehaviorResult::Running
+    );
+
+    assert_eq!(res, vec![true]);
+
+    // Even ticking again won't invoke push(false)
+    tree.tick(
+        &mut |v: &dyn std::any::Any| {
+            res.push(*v.downcast_ref::<bool>().unwrap());
+            None
+        },
+        &mut Context::default(),
+    );
+
+    assert_eq!(res, vec![true]);
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,7 @@
+mod nom_parser;
+
 use crate::{error::Error, BehaviorNode, FallbackNode, SequenceNode};
+pub use nom_parser::{node_def, parse_file, parse_nodes, NodeDef};
 use serde_yaml::Value;
 use std::collections::HashMap;
 use symbol::Symbol;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,8 @@
+mod loader;
 mod nom_parser;
 
 use crate::{error::Error, BehaviorNode, FallbackNode, SequenceNode};
+pub use loader::load;
 pub use nom_parser::{node_def, parse_file, parse_nodes, NodeDef};
 use serde_yaml::Value;
 use std::collections::HashMap;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,20 +10,20 @@ use symbol::Symbol;
 
 pub trait Constructor: Fn() -> Box<dyn BehaviorNode> {}
 
-pub struct Registry<E = ()> {
-    node_types: HashMap<String, Box<dyn Fn() -> Box<dyn BehaviorNode<E>>>>,
+pub struct Registry {
+    node_types: HashMap<String, Box<dyn Fn() -> Box<dyn BehaviorNode>>>,
     key_names: HashMap<String, Symbol>,
 }
 
-fn sequence_constructor<E: 'static>() -> Box<dyn BehaviorNode<E> + 'static> {
-    Box::new(SequenceNode::<E>::default())
+fn sequence_constructor() -> Box<dyn BehaviorNode + 'static> {
+    Box::new(SequenceNode::default())
 }
 
-fn fallback_constructor<E: 'static>() -> Box<dyn BehaviorNode<E> + 'static> {
-    Box::new(FallbackNode::<E>::default())
+fn fallback_constructor() -> Box<dyn BehaviorNode + 'static> {
+    Box::new(FallbackNode::default())
 }
 
-impl<E: 'static> Default for Registry<E> {
+impl Default for Registry {
     fn default() -> Self {
         let mut ret = Self {
             node_types: HashMap::new(),
@@ -35,16 +35,16 @@ impl<E: 'static> Default for Registry<E> {
     }
 }
 
-impl<E> Registry<E> {
+impl Registry {
     pub fn register(
         &mut self,
         type_name: impl ToString,
-        constructor: Box<dyn Fn() -> Box<dyn BehaviorNode<E>>>,
+        constructor: Box<dyn Fn() -> Box<dyn BehaviorNode>>,
     ) {
         self.node_types.insert(type_name.to_string(), constructor);
     }
 
-    pub fn build(&self, type_name: &str) -> Option<Box<dyn BehaviorNode<E>>> {
+    pub fn build(&self, type_name: &str) -> Option<Box<dyn BehaviorNode>> {
         self.node_types
             .get(type_name)
             .map(|constructor| constructor())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 mod loader;
 mod nom_parser;
 
-use crate::{error::Error, BehaviorNode, FallbackNode, SequenceNode};
+use crate::{error::Error, BBMap, BehaviorNode, BlackboardValue, FallbackNode, SequenceNode};
 pub use loader::load;
 pub use nom_parser::{node_def, parse_file, parse_nodes, NodeDef};
 use serde_yaml::Value;
@@ -54,7 +54,7 @@ impl Registry {
 fn recurse_parse(
     value: &serde_yaml::Value,
     reg: &Registry,
-) -> serde_yaml::Result<Option<(Box<dyn BehaviorNode>, HashMap<Symbol, Symbol>)>> {
+) -> serde_yaml::Result<Option<(Box<dyn BehaviorNode>, BBMap)>> {
     let mut node = if let Some(node) =
         value
             .get("type")
@@ -82,7 +82,10 @@ fn recurse_parse(
             .iter()
             .filter_map(|(key, value)| {
                 key.as_str().zip(value.as_str()).and_then(|(key, value)| {
-                    Some((*reg.key_names.get(key)?, *reg.key_names.get(value)?))
+                    Some((
+                        *reg.key_names.get(key)?,
+                        BlackboardValue::Ref(*reg.key_names.get(value)?),
+                    ))
                 })
             })
             .collect()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,20 +10,20 @@ use symbol::Symbol;
 
 pub trait Constructor: Fn() -> Box<dyn BehaviorNode> {}
 
-pub struct Registry {
-    node_types: HashMap<String, Box<dyn Fn() -> Box<dyn BehaviorNode>>>,
+pub struct Registry<E = ()> {
+    node_types: HashMap<String, Box<dyn Fn() -> Box<dyn BehaviorNode<E>>>>,
     key_names: HashMap<String, Symbol>,
 }
 
-fn sequence_constructor() -> Box<dyn BehaviorNode> {
-    Box::new(SequenceNode::default())
+fn sequence_constructor<E: 'static>() -> Box<dyn BehaviorNode<E> + 'static> {
+    Box::new(SequenceNode::<E>::default())
 }
 
-fn fallback_constructor() -> Box<dyn BehaviorNode> {
-    Box::new(FallbackNode::default())
+fn fallback_constructor<E: 'static>() -> Box<dyn BehaviorNode<E> + 'static> {
+    Box::new(FallbackNode::<E>::default())
 }
 
-impl Default for Registry {
+impl<E: 'static> Default for Registry<E> {
     fn default() -> Self {
         let mut ret = Self {
             node_types: HashMap::new(),
@@ -35,16 +35,16 @@ impl Default for Registry {
     }
 }
 
-impl Registry {
+impl<E> Registry<E> {
     pub fn register(
         &mut self,
         type_name: impl ToString,
-        constructor: Box<dyn Fn() -> Box<dyn BehaviorNode>>,
+        constructor: Box<dyn Fn() -> Box<dyn BehaviorNode<E>>>,
     ) {
         self.node_types.insert(type_name.to_string(), constructor);
     }
 
-    pub fn build(&self, type_name: &str) -> Option<Box<dyn BehaviorNode>> {
+    pub fn build(&self, type_name: &str) -> Option<Box<dyn BehaviorNode<E>>> {
         self.node_types
             .get(type_name)
             .map(|constructor| constructor())

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use super::nom_parser::{TreeDef, TreeSource};
 use crate::{BehaviorNode, Registry};
 
-pub fn load(
+pub fn load<E>(
     tree_source: &TreeSource,
-    registry: &Registry,
-) -> Result<Box<dyn BehaviorNode>, String> {
+    registry: &Registry<E>,
+) -> Result<Box<dyn BehaviorNode<E>>, String> {
     let main = tree_source
         .tree_defs
         .iter()
@@ -16,7 +16,10 @@ pub fn load(
     load_recurse(&main.root, registry)
 }
 
-fn load_recurse(parent: &TreeDef, registry: &Registry) -> Result<Box<dyn BehaviorNode>, String> {
+fn load_recurse<E>(
+    parent: &TreeDef,
+    registry: &Registry<E>,
+) -> Result<Box<dyn BehaviorNode<E>>, String> {
     let mut ret = registry
         .build(parent.ty)
         .ok_or_else(|| format!("Type not found {:?}", parent.ty))?;

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -1,0 +1,29 @@
+use std::collections::HashMap;
+
+use super::nom_parser::{TreeDef, TreeSource};
+use crate::{BehaviorNode, Registry};
+
+pub fn load(
+    tree_source: &TreeSource,
+    registry: &Registry,
+) -> Result<Box<dyn BehaviorNode>, String> {
+    let main = tree_source
+        .tree_defs
+        .iter()
+        .find(|tree| tree.name == "main")
+        .ok_or_else(|| "Main tree does not exist".to_string())?;
+
+    load_recurse(&main.root, registry)
+}
+
+fn load_recurse(parent: &TreeDef, registry: &Registry) -> Result<Box<dyn BehaviorNode>, String> {
+    let mut ret = registry
+        .build(parent.ty)
+        .ok_or_else(|| format!("Type not found {:?}", parent.ty))?;
+
+    for child in &parent.children {
+        ret.add_child(load_recurse(child, registry)?, HashMap::new());
+    }
+
+    Ok(ret)
+}

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use super::nom_parser::{TreeDef, TreeSource};
 use crate::{BehaviorNode, Registry};
 
-pub fn load<E>(
+pub fn load(
     tree_source: &TreeSource,
-    registry: &Registry<E>,
-) -> Result<Box<dyn BehaviorNode<E>>, String> {
+    registry: &Registry,
+) -> Result<Box<dyn BehaviorNode>, String> {
     let main = tree_source
         .tree_defs
         .iter()
@@ -16,10 +16,7 @@ pub fn load<E>(
     load_recurse(&main.root, registry)
 }
 
-fn load_recurse<E>(
-    parent: &TreeDef,
-    registry: &Registry<E>,
-) -> Result<Box<dyn BehaviorNode<E>>, String> {
+fn load_recurse(parent: &TreeDef, registry: &Registry) -> Result<Box<dyn BehaviorNode>, String> {
     let mut ret = registry
         .build(parent.ty)
         .ok_or_else(|| format!("Type not found {:?}", parent.ty))?;

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use super::nom_parser::{TreeDef, TreeSource};
 use crate::{BBMap, BehaviorNode, Registry};
 

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -102,9 +102,9 @@ pub fn parse_nodes<'src>(i: &'src str) -> IResult<&'src str, Vec<NodeDef<'src>>>
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TreeDef<'src> {
-    ty: &'src str,
+    pub(crate) ty: &'src str,
     port_maps: Vec<PortMap<'src>>,
-    children: Vec<TreeDef<'src>>,
+    pub(crate) children: Vec<TreeDef<'src>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -116,8 +116,8 @@ pub struct PortMap<'src> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TreeRootDef<'src> {
-    name: &'src str,
-    root: TreeDef<'src>,
+    pub(crate) name: &'src str,
+    pub(crate) root: TreeDef<'src>,
 }
 
 fn parse_tree(i: &str) -> IResult<&str, TreeRootDef> {
@@ -236,8 +236,8 @@ pub fn parse_file(i: &str) -> IResult<&str, TreeSource> {
 
 #[derive(Debug, PartialEq)]
 pub struct TreeSource<'src> {
-    node_defs: Vec<NodeDef<'src>>,
-    tree_defs: Vec<TreeRootDef<'src>>,
+    pub node_defs: Vec<NodeDef<'src>>,
+    pub tree_defs: Vec<TreeRootDef<'src>>,
 }
 
 #[cfg(test)]

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -1,0 +1,422 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{alpha1, alphanumeric1, char, multispace0, one_of, space0},
+    combinator::{opt, recognize},
+    multi::{many0, many1},
+    sequence::{delimited, pair},
+    IResult,
+};
+
+#[derive(Debug, PartialEq)]
+pub struct NodeDef<'src> {
+    name: &'src str,
+    input_ports: Vec<PortDef<'src>>,
+    output_ports: Vec<PortDef<'src>>,
+}
+
+impl<'src> NodeDef<'src> {
+    pub fn new(name: &'src str) -> Self {
+        Self {
+            name,
+            input_ports: Vec::new(),
+            output_ports: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct PortDef<'src> {
+    name: &'src str,
+    ty: &'src str,
+}
+
+fn identifier(input: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        alt((alpha1, tag("_"))),
+        many0(alt((alphanumeric1, tag("_")))),
+    ))(input)
+}
+
+fn newlines(i: &str) -> IResult<&str, ()> {
+    delimited(space0, many1(one_of("\r\n")), space0)(i).map(|(rest, _)| (rest, ()))
+}
+
+fn port_def<'src>(i: &'src str) -> IResult<&'src str, (bool, PortDef<'src>)> {
+    let (i, inout) = delimited(space0, alt((tag("in"), tag("out"))), space0)(i)?;
+    let (i, name) = identifier(i)?;
+    let (i, _) = delimited(space0, char(':'), space0)(i)?;
+    let (i, ty) = identifier(i)?;
+    let (i, _) = newlines(i)?;
+    Ok((i, (inout == "in", PortDef { name, ty })))
+}
+
+fn ports_def<'src>(i: &'src str) -> IResult<&'src str, Vec<(bool, PortDef<'src>)>> {
+    let (i, _) = many0(newlines)(i)?;
+
+    let (i, v) = many0(delimited(space0, port_def, many0(pair(space0, newlines))))(i)?;
+
+    let (i, _) = many0(newlines)(i)?;
+
+    Ok((i, v))
+}
+
+pub fn node_def<'src>(i: &'src str) -> IResult<&'src str, NodeDef<'src>> {
+    let (i, _) = delimited(multispace0, tag("node"), space0)(i)?;
+
+    let (i, name) = delimited(space0, alphanumeric1, space0)(i)?;
+
+    let (i, ports) = delimited(
+        delimited(space0, char('{'), space0),
+        ports_def,
+        delimited(space0, char('}'), space0),
+    )(i)?;
+
+    let (input_ports, output_ports) = ports.into_iter().fold(
+        (vec![], vec![]),
+        |(mut in_vec, mut out_vec), (inout, cur)| {
+            if inout {
+                in_vec.push(cur);
+            } else {
+                out_vec.push(cur);
+            }
+            (in_vec, out_vec)
+        },
+    );
+    // let input_ports = vec![];
+    // let output_ports = vec![];
+
+    Ok((
+        i,
+        NodeDef {
+            name,
+            input_ports,
+            output_ports,
+        },
+    ))
+}
+
+pub fn parse_nodes<'src>(i: &'src str) -> IResult<&'src str, Vec<NodeDef<'src>>> {
+    many0(node_def)(i)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TreeDef<'src> {
+    ty: &'src str,
+    port_maps: Vec<PortMap<'src>>,
+    children: Vec<TreeDef<'src>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PortMap<'src> {
+    input: bool,
+    node_port: &'src str,
+    blackboard_name: &'src str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TreeRootDef<'src> {
+    name: &'src str,
+    root: TreeDef<'src>,
+}
+
+fn parse_tree(i: &str) -> IResult<&str, TreeRootDef> {
+    let (i, _) = delimited(multispace0, tag("tree"), space0)(i)?;
+
+    let (i, name) = delimited(space0, identifier, space0)(i)?;
+
+    let (i, _) = delimited(space0, tag("="), space0)(i)?;
+
+    let (i, root) = parse_tree_node(i)?;
+
+    Ok((i, TreeRootDef { name, root }))
+}
+
+fn tree_children(i: &str) -> IResult<&str, Vec<TreeDef>> {
+    let (i, _) = many0(newlines)(i)?;
+
+    let (i, v) = many0(delimited(
+        space0,
+        parse_tree_node,
+        many0(pair(space0, newlines)),
+    ))(i)?;
+
+    let (i, _) = many0(newlines)(i)?;
+
+    Ok((i, v))
+}
+
+fn parse_tree_node(i: &str) -> IResult<&str, TreeDef> {
+    let (i, ty) = delimited(space0, identifier, space0)(i)?;
+
+    let (i, input_ports) = opt(delimited(
+        delimited(space0, char('('), space0),
+        port_maps,
+        delimited(space0, char(')'), space0),
+    ))(i)?;
+
+    let (i, children) = opt(delimited(
+        delimited(space0, char('{'), space0),
+        tree_children,
+        delimited(space0, char('}'), space0),
+    ))(i)?;
+
+    Ok((
+        i,
+        TreeDef {
+            ty,
+            port_maps: input_ports.unwrap_or(vec![]),
+            children: children.unwrap_or(vec![]),
+        },
+    ))
+}
+
+fn port_maps(i: &str) -> IResult<&str, Vec<PortMap>> {
+    many0(delimited(
+        multispace0,
+        port_map,
+        many0(pair(multispace0, char(','))),
+    ))(i)
+}
+
+fn port_map(i: &str) -> IResult<&str, PortMap> {
+    let (i, node_port) = delimited(space0, identifier, space0)(i)?;
+
+    let (i, inout) = delimited(space0, alt((tag("<-"), tag("->"))), space0)(i)?;
+
+    let (i, blackboard_name) = delimited(space0, identifier, space0)(i)?;
+
+    Ok((
+        i,
+        PortMap {
+            input: inout == "<-",
+            node_port,
+            blackboard_name,
+        },
+    ))
+}
+
+pub fn parse_trees(i: &str) -> IResult<&str, Vec<TreeRootDef>> {
+    many0(parse_tree)(i)
+}
+
+pub fn parse_file(i: &str) -> IResult<&str, TreeSource> {
+    enum NodeOrTree<'src> {
+        Node(NodeDef<'src>),
+        Tree(TreeRootDef<'src>),
+    }
+
+    let (i, stmts) = many0(alt((
+        |i| {
+            let (i, node) = node_def(i)?;
+            Ok((i, NodeOrTree::Node(node)))
+        },
+        |i| {
+            let (i, tree) = parse_tree(i)?;
+            Ok((i, NodeOrTree::Tree(tree)))
+        },
+    )))(i)?;
+
+    let (node_defs, tree_defs) = stmts.into_iter().fold((vec![], vec![]), |mut acc, cur| {
+        match cur {
+            NodeOrTree::Node(node) => acc.0.push(node),
+            NodeOrTree::Tree(tree) => acc.1.push(tree),
+        }
+        acc
+    });
+
+    Ok((
+        i,
+        TreeSource {
+            node_defs,
+            tree_defs,
+        },
+    ))
+}
+
+#[derive(Debug, PartialEq)]
+pub struct TreeSource<'src> {
+    node_defs: Vec<NodeDef<'src>>,
+    tree_defs: Vec<TreeRootDef<'src>>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_nodes() {
+        assert_eq!(
+            parse_nodes(
+                "node A {
+        }"
+            ),
+            Ok((
+                "",
+                vec![NodeDef {
+                    name: "A",
+                    input_ports: vec![],
+                    output_ports: vec![],
+                }]
+            ))
+        );
+
+        assert_eq!(
+            parse_nodes(
+                "node A {
+            in A: Arm
+            out B: Body
+        }"
+            ),
+            Ok((
+                "",
+                vec![NodeDef {
+                    name: "A",
+                    input_ports: vec![PortDef {
+                        name: "A",
+                        ty: "Arm",
+                    }],
+                    output_ports: vec![PortDef {
+                        name: "B",
+                        ty: "Body",
+                    }],
+                }]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_trees() {
+        assert_eq!(
+            parse_tree(
+                "tree main = Sequence {
+        }"
+            ),
+            Ok((
+                "",
+                TreeRootDef {
+                    name: "main",
+                    root: TreeDef {
+                        ty: "Sequence",
+                        port_maps: vec![],
+                        children: vec![]
+                    }
+                }
+            ))
+        );
+
+        assert_eq!(
+            parse_tree(
+                "tree main = Sequence {
+                    PrintBodyNode
+        }"
+            ),
+            Ok((
+                "",
+                TreeRootDef {
+                    name: "main",
+                    root: TreeDef {
+                        ty: "Sequence",
+                        port_maps: vec![],
+                        children: vec![TreeDef {
+                            ty: "PrintBodyNode",
+                            port_maps: vec![],
+                            children: vec![]
+                        }]
+                    }
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_tree_ports() {
+        assert_eq!(
+            parse_tree(
+                "tree main = Sequence {
+                PrintBodyNode(in_socket <- in_val, out_socket -> out_val)
+    }"
+            ),
+            Ok((
+                "",
+                TreeRootDef {
+                    name: "main",
+                    root: TreeDef {
+                        ty: "Sequence",
+                        port_maps: vec![],
+                        children: vec![TreeDef {
+                            ty: "PrintBodyNode",
+                            port_maps: vec![
+                                PortMap {
+                                    input: true,
+                                    node_port: "in_socket",
+                                    blackboard_name: "in_val",
+                                },
+                                PortMap {
+                                    input: false,
+                                    node_port: "out_socket",
+                                    blackboard_name: "out_val",
+                                }
+                            ],
+                            children: vec![]
+                        }]
+                    }
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_file() {
+        assert_eq!(
+            parse_file(
+                "node A {
+            in A: Arm
+            out B: Body
+        }
+        tree main = Sequence {
+            PrintBodyNode(in_socket <- in_val, out_socket -> out_val)
+        }"
+            ),
+            Ok((
+                "",
+                TreeSource {
+                    node_defs: vec![NodeDef {
+                        name: "A",
+                        input_ports: vec![PortDef {
+                            name: "A",
+                            ty: "Arm",
+                        }],
+                        output_ports: vec![PortDef {
+                            name: "B",
+                            ty: "Body"
+                        }],
+                    }],
+                    tree_defs: vec![TreeRootDef {
+                        name: "main",
+                        root: TreeDef {
+                            ty: "Sequence",
+                            port_maps: vec![],
+                            children: vec![TreeDef {
+                                ty: "PrintBodyNode",
+                                port_maps: vec![
+                                    PortMap {
+                                        input: true,
+                                        node_port: "in_socket",
+                                        blackboard_name: "in_val",
+                                    },
+                                    PortMap {
+                                        input: false,
+                                        node_port: "out_socket",
+                                        blackboard_name: "out_val",
+                                    }
+                                ],
+                                children: vec![],
+                            }]
+                        }
+                    }],
+                }
+            ))
+        );
+    }
+}

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -224,9 +224,6 @@ fn str_literal(input: &str) -> IResult<&str, BlackboardValue> {
         ),
     ))
 }
-pub fn parse_trees(i: &str) -> IResult<&str, Vec<TreeRootDef>> {
-    many0(parse_tree)(i)
-}
 
 pub fn parse_file(i: &str) -> IResult<&str, TreeSource> {
     enum NodeOrTree<'src> {

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -103,7 +103,7 @@ pub fn parse_nodes<'src>(i: &'src str) -> IResult<&'src str, Vec<NodeDef<'src>>>
 #[derive(Debug, PartialEq, Eq)]
 pub struct TreeDef<'src> {
     pub(crate) ty: &'src str,
-    port_maps: Vec<PortMap<'src>>,
+    pub(crate) port_maps: Vec<PortMap<'src>>,
     pub(crate) children: Vec<TreeDef<'src>>,
 }
 
@@ -116,9 +116,9 @@ pub enum BlackboardValue<'src> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PortMap<'src> {
-    input: bool,
-    node_port: &'src str,
-    blackboard_value: BlackboardValue<'src>,
+    pub(crate) input: bool,
+    pub(crate) node_port: &'src str,
+    pub(crate) blackboard_value: BlackboardValue<'src>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/test.txt
+++ b/test.txt
@@ -13,6 +13,6 @@ tree main = Sequence {
   Sequence {
     PrintArmNode (arm <- left_arm)
     PrintArmNode (arm <- right_arm)
-    PrintArmNode (arm <- right_arm)
+    PrintStringNode (input <- "literal message")
   }
 }

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,17 @@
+
+node PrintArmNode {
+  in arm: Arm
+}
+
+node PrintBodyNode {
+  out left_arm: Arm
+  out right_arm: Arm
+}
+
+tree main = Sequence {
+  PrintBodyNode (left_arm -> left_arm, right_arm -> right_arm)
+  Sequence {
+    PrintArmNode (arm <- left_arm)
+    PrintArmNode (arm <- right_arm)
+  }
+}

--- a/test.txt
+++ b/test.txt
@@ -13,5 +13,6 @@ tree main = Sequence {
   Sequence {
     PrintArmNode (arm <- left_arm)
     PrintArmNode (arm <- right_arm)
+    PrintArmNode (arm <- right_arm)
   }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,12 +2,13 @@
 use behavior_tree_lite::{
     hash_map, BehaviorNode, BehaviorResult, Context, FallbackNode, SequenceNode,
 };
+use symbol::Symbol;
 
 struct CheckMeNode;
 
 impl BehaviorNode for CheckMeNode {
     fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
-        assert_eq!(Some(&"check me"), ctx.get::<&str>("check"));
+        assert_eq!(Some(&"check me"), ctx.get(Symbol::from("check")));
         BehaviorResult::Success
     }
 }
@@ -15,7 +16,7 @@ impl BehaviorNode for CheckMeNode {
 #[test]
 fn test_check() {
     let mut ctx = Context::default();
-    ctx.set("check", "check me");
+    ctx.set(Symbol::from("check"), "check me");
     let mut print_arm = CheckMeNode;
     print_arm.tick(&mut ctx);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,17 +1,13 @@
 // use std::convert::From;
 use behavior_tree_lite::{
-    hash_map, BehaviorNode, BehaviorResult, Context, FallbackNode, SequenceNode,
+    hash_map, BehaviorCallback, BehaviorNode, BehaviorResult, Context, FallbackNode, SequenceNode,
 };
 use symbol::Symbol;
 
 struct CheckMeNode;
 
 impl BehaviorNode for CheckMeNode {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
         assert_eq!(Some(&"check me"), ctx.get(Symbol::from("check")));
         BehaviorResult::Success
     }
@@ -22,17 +18,13 @@ fn test_check() {
     let mut ctx = Context::default();
     ctx.set(Symbol::from("check"), "check me");
     let mut print_arm = CheckMeNode;
-    print_arm.tick(&mut |_| (), &mut ctx);
+    print_arm.tick(&mut |_| None, &mut ctx);
 }
 
 struct AlwaysSucceed;
 
 impl BehaviorNode for AlwaysSucceed {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        _ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
         BehaviorResult::Success
     }
 }
@@ -40,11 +32,7 @@ impl BehaviorNode for AlwaysSucceed {
 struct AlwaysFail;
 
 impl BehaviorNode for AlwaysFail {
-    fn tick(
-        &mut self,
-        _arg: &mut dyn FnMut(&dyn std::any::Any),
-        _ctx: &mut Context,
-    ) -> BehaviorResult {
+    fn tick(&mut self, _arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
         BehaviorResult::Fail
     }
 }
@@ -55,12 +43,12 @@ fn test_sequence() {
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
     assert_eq!(
-        seq.tick(&mut |_| (), &mut Context::default()),
+        seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Success
     );
     seq.add_child(Box::new(AlwaysFail), hash_map!());
     assert_eq!(
-        seq.tick(&mut |_| (), &mut Context::default()),
+        seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Fail
     );
 }
@@ -71,12 +59,12 @@ fn test_fallback() {
     seq.add_child(Box::new(AlwaysFail), hash_map!());
     seq.add_child(Box::new(AlwaysFail), hash_map!());
     assert_eq!(
-        seq.tick(&mut |_| (), &mut Context::default()),
+        seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Fail
     );
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
     assert_eq!(
-        seq.tick(&mut |_| (), &mut Context::default()),
+        seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Success
     );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,7 +7,11 @@ use symbol::Symbol;
 struct CheckMeNode;
 
 impl BehaviorNode for CheckMeNode {
-    fn tick(&mut self, ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        ctx: &mut Context,
+    ) -> BehaviorResult {
         assert_eq!(Some(&"check me"), ctx.get(Symbol::from("check")));
         BehaviorResult::Success
     }
@@ -18,13 +22,17 @@ fn test_check() {
     let mut ctx = Context::default();
     ctx.set(Symbol::from("check"), "check me");
     let mut print_arm = CheckMeNode;
-    print_arm.tick(&mut ctx);
+    print_arm.tick(&mut |_| (), &mut ctx);
 }
 
 struct AlwaysSucceed;
 
 impl BehaviorNode for AlwaysSucceed {
-    fn tick(&mut self, _ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        _ctx: &mut Context,
+    ) -> BehaviorResult {
         BehaviorResult::Success
     }
 }
@@ -32,7 +40,11 @@ impl BehaviorNode for AlwaysSucceed {
 struct AlwaysFail;
 
 impl BehaviorNode for AlwaysFail {
-    fn tick(&mut self, _ctx: &mut Context) -> BehaviorResult {
+    fn tick(
+        &mut self,
+        _arg: &mut dyn FnMut(&dyn std::any::Any),
+        _ctx: &mut Context,
+    ) -> BehaviorResult {
         BehaviorResult::Fail
     }
 }
@@ -42,9 +54,15 @@ fn test_sequence() {
     let mut seq = SequenceNode::default();
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
-    assert_eq!(seq.tick(&mut Context::default()), BehaviorResult::Success);
+    assert_eq!(
+        seq.tick(&mut |_| (), &mut Context::default()),
+        BehaviorResult::Success
+    );
     seq.add_child(Box::new(AlwaysFail), hash_map!());
-    assert_eq!(seq.tick(&mut Context::default()), BehaviorResult::Fail);
+    assert_eq!(
+        seq.tick(&mut |_| (), &mut Context::default()),
+        BehaviorResult::Fail
+    );
 }
 
 #[test]
@@ -52,7 +70,13 @@ fn test_fallback() {
     let mut seq = FallbackNode::default();
     seq.add_child(Box::new(AlwaysFail), hash_map!());
     seq.add_child(Box::new(AlwaysFail), hash_map!());
-    assert_eq!(seq.tick(&mut Context::default()), BehaviorResult::Fail);
+    assert_eq!(
+        seq.tick(&mut |_| (), &mut Context::default()),
+        BehaviorResult::Fail
+    );
     seq.add_child(Box::new(AlwaysSucceed), hash_map!());
-    assert_eq!(seq.tick(&mut Context::default()), BehaviorResult::Success);
+    assert_eq!(
+        seq.tick(&mut |_| (), &mut Context::default()),
+        BehaviorResult::Success
+    );
 }


### PR DESCRIPTION
We have quite a lot in this PR.

* Change the behavior node constructor's type to simple `Fn() -> Box<dyn BehaviorNode>`
* Converting port names from strings to Symbols
* Providing means for the behavior nodes to interact with the environment with a callback
* Implement DSL for descirbing behavior tree
* Implement Running result, ReactiveSequence and ReactiveFallback

# SImpler constructor type

We had specific trait for the constructor

```rust
pub trait Constructor {
    fn build(&self) -> Box<dyn BehaviorNode>;
}
```

but this trait is not very ergonomic in that it only provides a function.
It can simply be a `Fn() -> Box<dyn BehaviorNode>` trait.

We may revisit and add other methods, such as allowed ports, but that's for another PR.

# Port names as Symbols

[Symbol crate](https://github.com/remexre/symbol-rs) can optimize the comparison of port names and enhance performance if a lot of ports are used.

# Providing environment interaction

The `tick()` method now has an argument with a type `BehaviorCallback` which can be called from behavior node to communicate with the environment.

# DSL for behavior tree

Implemented with `nom`. It is much more concise than XML or even YAML and optimized for descibing behavior tree.

For example:

```
node A {
   in A: Arm
   out B: Body
}
tree main = Sequence {
   PrintBodyNode(in_socket <- in_val, out_socket -> out_val)
}
```

# Runing result, ReactiveSequence and ReactiveFallback

See [the BehaviorTree.CPP's documentation](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_04_sequence) about what they do.
