### PR TITLE
Publish vscode extension using github action

### DIFF
--- a/.github/workflows/publish-vscode-ext.yml
+++ b/.github/workflows/publish-vscode-ext.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Deploy Extension
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+      - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com

--- a/.github/workflows/publish-vscode-ext.yml
+++ b/.github/workflows/publish-vscode-ext.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    tags:
-      - "*"
+    paths:
+      - "vs-codex/**"
 
 name: Deploy Extension
 jobs:

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -10,6 +10,7 @@
   "categories": [
     "Programming Languages"
   ],
+  "publisher": "msakuta",
   "contributes": {
     "languages": [{
       "id": "rustybtlite",


### PR DESCRIPTION
fixed #4 

using this github action
- https://github.com/marketplace/actions/publish-vs-code-extension

vscode ext publish reference
- https://code.visualstudio.com/api/working-with-extensions/publishing-extension