### PR TITLE
Move child nodes into BehaviorNodeContainer

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -2,7 +2,7 @@ use ::behavior_tree_lite::{
     hash_map, BehaviorCallback, BehaviorNode, BehaviorResult, BlackboardValue, Context, Lazy,
     SequenceNode, Symbol,
 };
-use behavior_tree_lite::PortType;
+use behavior_tree_lite::{BehaviorNodeContainer, PortType};
 
 #[derive(Clone, Debug)]
 struct Arm {
@@ -60,26 +60,29 @@ fn main() {
     let mut ctx = Context::default();
     ctx.set("body", body);
 
-    let mut root = SequenceNode::default();
+    let mut root = BehaviorNodeContainer::new_node(SequenceNode::default());
 
-    root.add_child(Box::new(PrintBodyNode), hash_map!())
-        .unwrap();
+    root.add_child(BehaviorNodeContainer::new(
+        Box::new(PrintBodyNode),
+        hash_map!(),
+    ))
+    .unwrap();
 
-    let mut print_arms = SequenceNode::default();
+    let mut print_arms = BehaviorNodeContainer::new_node(SequenceNode::default());
     print_arms
-        .add_child(
+        .add_child(BehaviorNodeContainer::new(
             Box::new(PrintArmNode),
             hash_map!("arm" => BlackboardValue::Ref("left_arm".into(), PortType::InOut)),
-        )
+        ))
         .unwrap();
     print_arms
-        .add_child(
+        .add_child(BehaviorNodeContainer::new(
             Box::new(PrintArmNode),
             hash_map!("arm" => BlackboardValue::Ref("right_arm".into(), PortType::InOut)),
-        )
+        ))
         .unwrap();
 
-    root.add_child(Box::new(print_arms), hash_map!()).unwrap();
+    root.add_child(print_arms).unwrap();
 
     root.tick(&mut |_| None, &mut ctx);
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+use crate::{
+    error::{AddChildError, AddChildResult},
+    BehaviorCallback, BehaviorNode, BehaviorResult, BlackboardValue, Context, NumChildren, Symbol,
+};
+
+pub struct BehaviorNodeContainer {
+    pub(crate) node: Box<dyn BehaviorNode>,
+    pub(crate) blackboard_map: HashMap<Symbol, BlackboardValue>,
+    pub(crate) child_nodes: Vec<BehaviorNodeContainer>,
+}
+
+impl BehaviorNodeContainer {
+    pub fn new(
+        node: Box<dyn BehaviorNode>,
+        blackboard_map: HashMap<Symbol, BlackboardValue>,
+    ) -> Self {
+        Self {
+            node,
+            blackboard_map,
+            child_nodes: vec![],
+        }
+    }
+
+    pub fn new_raw(node: Box<dyn BehaviorNode>) -> Self {
+        Self {
+            node,
+            blackboard_map: HashMap::new(),
+            child_nodes: vec![],
+        }
+    }
+
+    pub fn new_node(node: impl BehaviorNode + 'static) -> Self {
+        Self {
+            node: Box::new(node),
+            blackboard_map: HashMap::new(),
+            child_nodes: vec![],
+        }
+    }
+
+    pub fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
+        std::mem::swap(&mut self.child_nodes, &mut ctx.child_nodes.0);
+        std::mem::swap(&mut self.blackboard_map, &mut ctx.blackboard_map);
+        let res = self.node.tick(arg, ctx);
+        std::mem::swap(&mut self.blackboard_map, &mut ctx.blackboard_map);
+        std::mem::swap(&mut self.child_nodes, &mut ctx.child_nodes.0);
+        res
+    }
+
+    pub fn add_child(&mut self, child: BehaviorNodeContainer) -> AddChildResult {
+        if NumChildren::Finite(self.child_nodes.len()) < self.node.num_children() {
+            self.child_nodes.push(child);
+            Ok(())
+        } else {
+            Err(AddChildError::TooManyNodes)
+        }
+    }
+}

--- a/src/container.rs
+++ b/src/container.rs
@@ -49,7 +49,7 @@ impl BehaviorNodeContainer {
     }
 
     pub fn add_child(&mut self, child: BehaviorNodeContainer) -> AddChildResult {
-        if NumChildren::Finite(self.child_nodes.len()) < self.node.num_children() {
+        if NumChildren::Finite(self.child_nodes.len()) < self.node.max_children() {
             self.child_nodes.push(child);
             Ok(())
         } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -29,7 +29,7 @@ impl<T: ?Sized> std::ops::Deref for DebugIgnore<T> {
 pub struct Context {
     pub(crate) blackboard: Blackboard,
     pub(crate) blackboard_map: BBMap,
-    pub(crate) children: DebugIgnore<Vec<BehaviorNodeContainer>>,
+    pub(crate) child_nodes: DebugIgnore<Vec<BehaviorNodeContainer>>,
     strict: bool,
 }
 
@@ -38,7 +38,7 @@ impl Context {
         Self {
             blackboard,
             blackboard_map: BBMap::new(),
-            children: DebugIgnore(vec![]),
+            child_nodes: DebugIgnore(vec![]),
             strict: true,
         }
     }
@@ -55,16 +55,16 @@ impl Context {
         self.strict = b;
     }
 
-    pub fn call_child(&mut self, idx: usize, arg: BehaviorCallback) -> Option<BehaviorResult> {
-        // Take the children temporarily to avoid borrow checker
-        let mut children = std::mem::take(&mut self.children.0);
+    pub fn tick_child(&mut self, idx: usize, arg: BehaviorCallback) -> Option<BehaviorResult> {
+        // Take the children temporarily because the context's `child_nodes` will be used by the child node (for grandchildren)
+        let mut children = std::mem::take(&mut self.child_nodes.0);
         let res = children.get_mut(idx).map(|child| child.tick(arg, self));
-        self.children.0 = children;
+        self.child_nodes.0 = children;
         res
     }
 
     pub fn num_children(&self) -> usize {
-        self.children.len()
+        self.child_nodes.len()
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,20 +1,44 @@
-use crate::{BBMap, Blackboard, BlackboardValue, PortType, Symbol};
+use crate::{
+    BBMap, BehaviorCallback, BehaviorNodeContainer, BehaviorResult, Blackboard, BlackboardValue,
+    PortType, Symbol,
+};
 use std::{any::Any, rc::Rc, str::FromStr};
 
+/// Our custom wrapper struct to stop propagation of Debug trait macro.
+/// Borrowed the concept from `debug-ignore` crate, but grossly simplified, and without dependency.
+#[derive(Default)]
+pub struct DebugIgnore<T: ?Sized>(pub T);
+
+impl<T: ?Sized> std::fmt::Debug for DebugIgnore<T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "...")
+    }
+}
+
+impl<T: ?Sized> std::ops::Deref for DebugIgnore<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Default, Debug)]
-pub struct Context<'e, T: 'e = ()> {
+pub struct Context {
     pub(crate) blackboard: Blackboard,
     pub(crate) blackboard_map: BBMap,
-    pub env: Option<&'e mut T>,
+    pub(crate) children: DebugIgnore<Vec<BehaviorNodeContainer>>,
     strict: bool,
 }
 
-impl<'e, T> Context<'e, T> {
+impl Context {
     pub fn new(blackboard: Blackboard) -> Self {
         Self {
             blackboard,
             blackboard_map: BBMap::new(),
-            env: None,
+            children: DebugIgnore(vec![]),
             strict: true,
         }
     }
@@ -30,15 +54,24 @@ impl<'e, T> Context<'e, T> {
     pub fn set_strict(&mut self, b: bool) {
         self.strict = b;
     }
+
+    pub fn call_child(&mut self, idx: usize, arg: BehaviorCallback) -> Option<BehaviorResult> {
+        // Take the children temporarily to avoid borrow checker
+        let mut children = std::mem::take(&mut self.children.0);
+        let res = children.get_mut(idx).map(|child| child.tick(arg, self));
+        self.children.0 = children;
+        res
+    }
+
+    pub fn num_children(&self) -> usize {
+        self.children.len()
+    }
 }
 
-impl<'e, E> Context<'e, E> {
+impl Context {
     /// Get a blackboard variable with downcasting to the type argument.
     /// Returns `None` if it fails to downcast.
-    pub fn get<'a, T: 'static>(&'a self, key: impl Into<Symbol>) -> Option<&'a T>
-    where
-        'e: 'a,
-    {
+    pub fn get<'a, T: 'static>(&'a self, key: impl Into<Symbol>) -> Option<&'a T> {
         let key: Symbol = key.into();
         let mapped = self.blackboard_map.get(&key);
         let mapped = match mapped {

--- a/src/context.rs
+++ b/src/context.rs
@@ -71,7 +71,7 @@ impl Context {
 impl Context {
     /// Get a blackboard variable with downcasting to the type argument.
     /// Returns `None` if it fails to downcast.
-    pub fn get<'a, T: 'static>(&'a self, key: impl Into<Symbol>) -> Option<&'a T> {
+    pub fn get<T: 'static>(&self, key: impl Into<Symbol>) -> Option<&T> {
         let key: Symbol = key.into();
         let mapped = self.blackboard_map.get(&key);
         let mapped = match mapped {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -670,7 +670,7 @@ mod container;
 mod context;
 pub mod error;
 mod nodes;
-mod parser;
+pub mod parser;
 mod port;
 mod registry;
 mod symbol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! ```rust
 //! # use behavior_tree_lite::Context;
 //! # let body = 1;
-//! let mut ctx = Context::<()>::default();
+//! let mut ctx = Context::default();
 //! ctx.set("body", body);
 //! ```
 //!
@@ -78,14 +78,14 @@
 //! # impl BehaviorNode for PrintBodyNode { fn tick(&mut self, _: BehaviorCallback, _: &mut Context) -> BehaviorResult { BehaviorResult::Success }}
 //! # struct PrintArmNode;
 //! # impl BehaviorNode for PrintArmNode { fn tick(&mut self, _: BehaviorCallback, _: &mut Context) -> BehaviorResult { BehaviorResult::Success }}
-//! let mut root = SequenceNode::default();
-//! root.add_child(Box::new(PrintBodyNode), hash_map!());
+//! let mut root = BehaviorNodeContainer::new_node(SequenceNode::default());
+//! root.add_child(BehaviorNodeContainer::new_node(PrintBodyNode));
 //!
-//! let mut print_arms = SequenceNode::default();
-//! print_arms.add_child(Box::new(PrintArmNode), hash_map!("arm" => "left_arm"));
-//! print_arms.add_child(Box::new(PrintArmNode), hash_map!("arm" => "right_arm"));
+//! let mut print_arms = BehaviorNodeContainer::new_node(SequenceNode::default());
+//! print_arms.add_child(BehaviorNodeContainer::new(Box::new(PrintArmNode), hash_map!("arm" => "left_arm")));
+//! print_arms.add_child(BehaviorNodeContainer::new(Box::new(PrintArmNode), hash_map!("arm" => "right_arm")));
 //!
-//! root.add_child(Box::new(print_arms), hash_map!());
+//! root.add_child(print_arms);
 //! ```
 //!
 //! and call `tick()`.
@@ -810,9 +810,11 @@ impl BehaviorNodeContainer {
     }
 
     pub fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
+        std::mem::swap(&mut self.child_nodes, &mut ctx.child_nodes.0);
         std::mem::swap(&mut self.blackboard_map, &mut ctx.blackboard_map);
         let res = self.node.tick(arg, ctx);
         std::mem::swap(&mut self.blackboard_map, &mut ctx.blackboard_map);
+        std::mem::swap(&mut self.child_nodes, &mut ctx.child_nodes.0);
         res
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ pub trait BehaviorNode {
 
     fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult;
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(0)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,38 +5,15 @@
 //!
 //! ## Overview
 //!
-//! This is a sister project of [tiny-behavior-tree](https://github.com/msakuta/rusty_tiny_behavior_tree) which in turn inspired by [BehaviorTreeCPP](https://github.com/BehaviorTree/BehaviorTree.CPP.git).
+//! This is an implementation of behavior tree in Rust, inspired by [BehaviorTreeCPP](https://github.com/BehaviorTree/BehaviorTree.CPP.git).
 //!
-//! While tiny-behavior-tree aims for more innovative design and experimental features, this crate aims for more traditional behavior tree implementation.
-//! However, we are not going to implement advanced features such as asynchronous nodes or coroutines.
-//! My goal is to make a crate lightweight enough to use in WebAssembly.
+//! A behavior tree is an extension to finite state machines that makes describing transitional behavior easier.
+//! See [BehaviorTreeCPP's documentation](https://www.behaviortree.dev/) for the thorough introduction to the idea.
 //!
-//! ## The difference from tiny-behavior-tree
+//! See the historical notes at the bottom of this README.md for more full history.
 //!
-//! The main premise of tiny-behavior-tree is that it passes data with function arguments.
-//! This is very good for making fast and small binary, but it suffers from mixed node types in a tree.
-//!
-//! It requires ugly boilerplate code or macros to convert types between different node argument types, and there is the concept of "PeelNode" which would be unnecessary in traditional behavior tree design.
-//!
-//! On top of that, uniform types make it much easier to implement configuration file parser that can change the behavior tree at runtime.
-//!
-//!
-//! ## Performance consideration
-//!
-//! One of the issues with behavior tree in general regarding performance is that the nodes communicate with blackboard variables, which is essentially a key-value store.
-//! It is not particularly bad, but if you read/write a lot of variables in the blackboard (which easily happens with a large behavior tree), you would pay the cost of constructing a string and looking up HashMap every time.
-//!
-//! One of the tiny-behavior-tree's goals is to address this issue by passing variables with function call arguments.
-//! Why would you pay the cost of looking up HashMap if you already know the address of the variable?
-//!
-//! Also, the blackboard is not very scalable, since it is essentially a huge table of global variables.
-//! Although there is sub-blackboards in subtrees, it is difficult to keep track of similar to scripting language's stack frame without proper debugging tools.
-//!
-//! I might experiment with non-string keys to make it more efficient, but the nature of the variables need to be handled dynamically in uniformly typeds nodes.
 //!
 //! ## How it looks like
-//!
-//! The usage is very similar to TinyBehaviorTree.
 //!
 //! First, you define the state with a data structure.
 //!
@@ -627,7 +604,7 @@
 //!
 //! tree-port-name = identifier
 //!
-//! node = if-syntax | conditional | var-def-syntax
+//! node = if-syntax | conditional | var-def-syntax | var-assign
 //!
 //! if-syntax = "if" "(" conditional ")"
 //!
@@ -649,6 +626,8 @@
 //!
 //! var-def-syntax = "var" identifier "=" initializer
 //!
+//! var-assign = identifier "=" initializer
+//!
 //! initializer = "true" | "false"
 //! ```
 //!
@@ -665,6 +644,35 @@
 //!   * [x] Programming language-like flow control syntax
 //! * [ ] Static type checking for behavior tree definition file
 //!
+//! # Historical notes
+//!
+//! This is a sister project of [tiny-behavior-tree](https://github.com/msakuta/rusty_tiny_behavior_tree) which in turn inspired by [BehaviorTreeCPP](https://github.com/BehaviorTree/BehaviorTree.CPP.git).
+//!
+//! While tiny-behavior-tree aims for more innovative design and experimental features, this crate aims for more traditional behavior tree implementation.
+//! The goal is to make a crate lightweight enough to use in WebAssembly.
+//!
+//! ## The difference from tiny-behavior-tree
+//!
+//! The main premise of tiny-behavior-tree is that it passes data with function arguments.
+//! This is very good for making fast and small binary, but it suffers from mixed node types in a tree.
+//!
+//! It requires ugly boilerplate code or macros to convert types between different node argument types, and there is the concept of "PeelNode" which would be unnecessary in traditional behavior tree design.
+//!
+//! On top of that, uniform types make it much easier to implement configuration file parser that can change the behavior tree at runtime.
+//!
+//!
+//! ## Performance consideration
+//!
+//! One of the issues with behavior tree in general regarding performance is that the nodes communicate with blackboard variables, which is essentially a key-value store.
+//! It is not particularly bad, but if you read/write a lot of variables in the blackboard (which easily happens with a large behavior tree), you would pay the cost of constructing a string and looking up HashMap every time.
+//!
+//! One of the tiny-behavior-tree's goals is to address this issue by passing variables with function call arguments.
+//! Why would you pay the cost of looking up HashMap if you already know the address of the variable?
+//!
+//! Also, the blackboard is not very scalable, since it is essentially a huge table of global variables.
+//! Although there is sub-blackboards in subtrees, it is difficult to keep track of similar to scripting language's stack frame without proper debugging tools.
+//!
+//! I might experiment with non-string keys to make it more efficient, but the nature of the variables need to be handled dynamically in uniformly typeds nodes.
 
 mod container;
 mod context;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -62,7 +62,7 @@ impl BehaviorNode for SubtreeNode {
         res.unwrap_or(BehaviorResult::Fail)
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -92,7 +92,7 @@ impl BehaviorNode for SequenceNode {
         BehaviorResult::Success
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Infinite
     }
 }
@@ -116,7 +116,7 @@ impl BehaviorNode for ReactiveSequenceNode {
         BehaviorResult::Success
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Infinite
     }
 }
@@ -146,7 +146,7 @@ impl BehaviorNode for FallbackNode {
         BehaviorResult::Fail
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Infinite
     }
 }
@@ -170,7 +170,7 @@ impl BehaviorNode for ReactiveFallbackNode {
         BehaviorResult::Fail
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Infinite
     }
 }
@@ -187,7 +187,7 @@ impl BehaviorNode for ForceSuccessNode {
         }
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -210,7 +210,7 @@ impl BehaviorNode for ForceFailureNode {
         }
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -228,7 +228,7 @@ impl BehaviorNode for InverterNode {
         }
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -267,7 +267,7 @@ impl BehaviorNode for RepeatNode {
         BehaviorResult::Fail
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -304,7 +304,7 @@ impl BehaviorNode for RetryNode {
         BehaviorResult::Fail
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(1)
     }
 }
@@ -390,7 +390,7 @@ impl BehaviorNode for IfNode {
         branch_result
     }
 
-    fn num_children(&self) -> NumChildren {
+    fn max_children(&self) -> NumChildren {
         NumChildren::Finite(3)
     }
 }

--- a/src/nodes/test.rs
+++ b/src/nodes/test.rs
@@ -373,7 +373,6 @@ struct Countdown<const C: usize>(usize);
 
 impl<const C: usize> BehaviorNode for Countdown<C> {
     fn tick(&mut self, _arg: BehaviorCallback, _ctx: &mut Context) -> BehaviorResult {
-        dbg!(self.0);
         if self.0 == 0 {
             self.0 = C;
             BehaviorResult::Success

--- a/src/nodes/test.rs
+++ b/src/nodes/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+type BNContainer = BehaviorNodeContainer;
 
 struct Append<const V: bool = true>;
 
@@ -18,10 +19,10 @@ fn test_sequence() {
         None
     };
 
-    let mut tree = SequenceNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(SequenceNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    tree.add_child(Box::new(Append::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Append::<false>))
         .unwrap();
 
     assert_eq!(
@@ -31,10 +32,10 @@ fn test_sequence() {
 
     assert_eq!(res, vec![true, false]);
 
-    let mut tree = SequenceNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(SequenceNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(AppendAndFail::<false>))
         .unwrap();
 
     assert_eq!(
@@ -55,11 +56,11 @@ impl BehaviorNode for Suspend {
 fn test_sequence_suspend() {
     let mut res = vec![];
 
-    let mut tree = SequenceNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(SequenceNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    tree.add_child(Box::new(Suspend), BBMap::new()).unwrap();
-    tree.add_child(Box::new(Append::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Suspend)).unwrap();
+    tree.add_child(BNContainer::new_node(Append::<false>))
         .unwrap();
 
     assert_eq!(
@@ -91,11 +92,11 @@ fn test_sequence_suspend() {
 fn test_reactive_sequence_suspend() {
     let mut res = vec![];
 
-    let mut tree = ReactiveSequenceNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(ReactiveSequenceNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    tree.add_child(Box::new(Suspend), BBMap::new()).unwrap();
-    tree.add_child(Box::new(Append::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Suspend)).unwrap();
+    tree.add_child(BNContainer::new_node(Append::<false>))
         .unwrap();
 
     assert_eq!(
@@ -141,10 +142,10 @@ fn test_fallback() {
         None
     };
 
-    let mut tree = FallbackNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(FallbackNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(AppendAndFail::<false>))
         .unwrap();
 
     assert_eq!(
@@ -154,10 +155,10 @@ fn test_fallback() {
 
     assert_eq!(res, vec![true, false]);
 
-    let mut tree = SequenceNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(SequenceNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    tree.add_child(Box::new(Append::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Append::<false>))
         .unwrap();
 }
 
@@ -165,11 +166,11 @@ fn test_fallback() {
 fn test_fallback_suspend() {
     let mut res = vec![];
 
-    let mut tree = FallbackNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(FallbackNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(Suspend), BBMap::new()).unwrap();
-    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Suspend)).unwrap();
+    tree.add_child(BNContainer::new_node(AppendAndFail::<false>))
         .unwrap();
 
     assert_eq!(
@@ -201,11 +202,11 @@ fn test_fallback_suspend() {
 fn test_reactive_fallback_suspend() {
     let mut res = vec![];
 
-    let mut tree = ReactiveFallbackNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(ReactiveFallbackNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(Suspend), BBMap::new()).unwrap();
-    tree.add_child(Box::new(AppendAndFail::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Suspend)).unwrap();
+    tree.add_child(BNContainer::new_node(AppendAndFail::<false>))
         .unwrap();
 
     assert_eq!(
@@ -251,9 +252,9 @@ impl BehaviorNode for AlwaysFail {
 
 #[test]
 fn test_force_success() {
-    let mut success_success = ForceSuccessNode::default();
+    let mut success_success = BNContainer::new_node(ForceSuccessNode::default());
     success_success
-        .add_child(Box::new(AlwaysSucceed), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysSucceed))
         .unwrap();
 
     assert_eq!(
@@ -261,9 +262,9 @@ fn test_force_success() {
         success_success.tick(&mut |_| None, &mut Context::default())
     );
 
-    let mut success_failure = ForceSuccessNode::default();
+    let mut success_failure = BNContainer::new_node(ForceSuccessNode::default());
     success_failure
-        .add_child(Box::new(AlwaysFail), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysFail))
         .unwrap();
 
     assert_eq!(
@@ -274,9 +275,9 @@ fn test_force_success() {
 
 #[test]
 fn test_force_failure() {
-    let mut failure_success = ForceFailureNode::default();
+    let mut failure_success = BNContainer::new_node(ForceFailureNode::default());
     failure_success
-        .add_child(Box::new(AlwaysSucceed), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysSucceed))
         .unwrap();
 
     assert_eq!(
@@ -284,9 +285,9 @@ fn test_force_failure() {
         failure_success.tick(&mut |_| None, &mut Context::default())
     );
 
-    let mut failure_failure = ForceFailureNode::default();
+    let mut failure_failure = BNContainer::new_node(ForceFailureNode::default());
     failure_failure
-        .add_child(Box::new(AlwaysFail), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysFail))
         .unwrap();
 
     assert_eq!(
@@ -297,9 +298,9 @@ fn test_force_failure() {
 
 #[test]
 fn test_inverter() {
-    let mut invert_success = InverterNode::default();
+    let mut invert_success = BNContainer::new_node(InverterNode::default());
     invert_success
-        .add_child(Box::new(AlwaysSucceed), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysSucceed))
         .unwrap();
 
     assert_eq!(
@@ -307,9 +308,9 @@ fn test_inverter() {
         invert_success.tick(&mut |_| None, &mut Context::default())
     );
 
-    let mut invert_failure = InverterNode::default();
+    let mut invert_failure = BNContainer::new_node(InverterNode::default());
     invert_failure
-        .add_child(Box::new(AlwaysFail), BBMap::new())
+        .add_child(BNContainer::new_node(AlwaysFail))
         .unwrap();
 
     assert_eq!(
@@ -317,9 +318,9 @@ fn test_inverter() {
         invert_failure.tick(&mut |_| None, &mut Context::default())
     );
 
-    let mut invert_running = InverterNode::default();
+    let mut invert_running = BNContainer::new_node(InverterNode::default());
     invert_running
-        .add_child(Box::new(Suspend), BBMap::new())
+        .add_child(BNContainer::new_node(Suspend))
         .unwrap();
 
     assert_eq!(
@@ -330,8 +331,8 @@ fn test_inverter() {
 
 #[test]
 fn test_repeat() {
-    let mut tree = RepeatNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RepeatNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -350,8 +351,8 @@ fn test_repeat() {
 
 #[test]
 fn test_repeat_fail() {
-    let mut tree = RepeatNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RepeatNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -384,24 +385,22 @@ impl<const C: usize> BehaviorNode for Countdown<C> {
 }
 
 impl<const C: usize> std::ops::Not for Countdown<C> {
-    type Output = InverterNode;
+    type Output = BNContainer;
 
     fn not(self) -> Self::Output {
-        let mut not = InverterNode::default();
-        not.add_child(Box::new(self), BBMap::new()).unwrap();
+        let mut not = BNContainer::new_node(InverterNode::default());
+        not.add_child(BNContainer::new_node(self)).unwrap();
         not
     }
 }
 
 #[test]
 fn test_repeat_break() {
-    let mut tree = FallbackNode::default();
-    let mut repeat = RepeatNode::default();
-    repeat
-        .add_child(Box::new(!Countdown::<2>(2)), BBMap::new())
-        .unwrap();
-    tree.add_child(Box::new(repeat), BBMap::new()).unwrap();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(FallbackNode::default());
+    let mut repeat = BNContainer::new_node(RepeatNode::default());
+    repeat.add_child(!Countdown::<2>(2)).unwrap();
+    tree.add_child(repeat).unwrap();
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -427,13 +426,12 @@ fn test_repeat_break() {
 
 #[test]
 fn test_repeat_suspend() {
-    let mut tree = RepeatNode::default();
-    let mut seq = SequenceNode::default();
-    seq.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RepeatNode::default());
+    let mut seq = BNContainer::new_node(SequenceNode::default());
+    seq.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    seq.add_child(Box::new(AlwaysRunning), BBMap::new())
-        .unwrap();
-    tree.add_child(Box::new(seq), BBMap::new()).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysRunning)).unwrap();
+    tree.add_child(seq).unwrap();
 
     let mut ctx = Context::default();
     ctx.set::<usize>("n", 3);
@@ -457,8 +455,8 @@ fn test_repeat_suspend() {
 
 #[test]
 fn test_retry() {
-    let mut tree = RetryNode::default();
-    tree.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RetryNode::default());
+    tree.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -477,8 +475,8 @@ fn test_retry() {
 
 #[test]
 fn test_retry_fail() {
-    let mut tree = RetryNode::default();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RetryNode::default());
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -497,13 +495,13 @@ fn test_retry_fail() {
 
 #[test]
 fn test_retry_break() {
-    let mut tree = SequenceNode::default();
-    let mut retry = RetryNode::default();
+    let mut tree = BNContainer::new_node(SequenceNode::default());
+    let mut retry = BNContainer::new_node(RetryNode::default());
     retry
-        .add_child(Box::new(Countdown::<2>(2)), BBMap::new())
+        .add_child(BNContainer::new_node(Countdown::<2>(2)))
         .unwrap();
-    tree.add_child(Box::new(retry), BBMap::new()).unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    tree.add_child(retry).unwrap();
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -529,13 +527,12 @@ fn test_retry_break() {
 
 #[test]
 fn test_retry_suspend() {
-    let mut tree = RetryNode::default();
-    let mut seq = SequenceNode::default();
-    seq.add_child(Box::new(Append::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(RetryNode::default());
+    let mut seq = BNContainer::new_node(SequenceNode::default());
+    seq.add_child(BNContainer::new_node(Append::<true>))
         .unwrap();
-    seq.add_child(Box::new(AlwaysRunning), BBMap::new())
-        .unwrap();
-    tree.add_child(Box::new(seq), BBMap::new()).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysRunning)).unwrap();
+    tree.add_child(seq).unwrap();
 
     let mut ctx = Context::default();
     ctx.set::<usize>("n", 3);
@@ -559,10 +556,10 @@ fn test_retry_suspend() {
 
 #[test]
 fn test_if_node() {
-    let mut tree = IfNode::default();
-    tree.add_child(Box::new(AlwaysSucceed), BBMap::new())
+    let mut tree = BNContainer::new_node(IfNode::default());
+    tree.add_child(BNContainer::new_node(AlwaysSucceed))
         .unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -583,11 +580,11 @@ fn test_if_node() {
 
 #[test]
 fn test_if_node_fail() {
-    let mut tree = IfNode::default();
-    tree.add_child(Box::new(AlwaysFail), BBMap::new()).unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(IfNode::default());
+    tree.add_child(BNContainer::new_node(AlwaysFail)).unwrap();
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(Append::<false>), BBMap::new())
+    tree.add_child(BNContainer::new_node(Append::<false>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -616,10 +613,10 @@ impl BehaviorNode for AlwaysRunning {
 
 #[test]
 fn test_if_node_suspend() {
-    let mut tree = IfNode::default();
-    tree.add_child(Box::new(AlwaysRunning), BBMap::new())
+    let mut tree = BNContainer::new_node(IfNode::default());
+    tree.add_child(BNContainer::new_node(AlwaysRunning))
         .unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -640,12 +637,12 @@ fn test_if_node_suspend() {
 
 #[test]
 fn test_if_node_true_suspend() {
-    let mut tree = IfNode::default();
-    tree.add_child(Box::new(AlwaysSucceed), BBMap::new())
+    let mut tree = BNContainer::new_node(IfNode::default());
+    tree.add_child(BNContainer::new_node(AlwaysSucceed))
         .unwrap();
-    tree.add_child(Box::new(AlwaysRunning), BBMap::new())
+    tree.add_child(BNContainer::new_node(AlwaysRunning))
         .unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
 
     let mut ctx = Context::default();
@@ -666,11 +663,11 @@ fn test_if_node_true_suspend() {
 
 #[test]
 fn test_if_node_false_suspend() {
-    let mut tree = IfNode::default();
-    tree.add_child(Box::new(AlwaysFail), BBMap::new()).unwrap();
-    tree.add_child(Box::new(AppendAndFail::<true>), BBMap::new())
+    let mut tree = BNContainer::new_node(IfNode::default());
+    tree.add_child(BNContainer::new_node(AlwaysFail)).unwrap();
+    tree.add_child(BNContainer::new_node(AppendAndFail::<true>))
         .unwrap();
-    tree.add_child(Box::new(AlwaysRunning), BBMap::new())
+    tree.add_child(BNContainer::new_node(AlwaysRunning))
         .unwrap();
 
     let mut ctx = Context::default();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,6 @@ mod yaml_parser;
 
 pub use self::{
     loader::load,
-    nom_parser::{node_def, parse_file, parse_nodes, NodeDef},
+    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef},
     yaml_parser::load_yaml,
 };

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -212,7 +212,7 @@ fn load_recurse(
         }
 
         if let Some(new_node) = new_node {
-            if NumChildren::Finite(ret.child_nodes.len()) < ret.node.num_children() {
+            if NumChildren::Finite(ret.child_nodes.len()) < ret.node.max_children() {
                 ret.child_nodes.push(new_node);
             } else {
                 return Err(LoadError::AddChildError(

--- a/src/parser/loader/test.rs
+++ b/src/parser/loader/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{boxify, error::LoadError, BehaviorResult, Context};
+use crate::{boxify, error::LoadError, BehaviorNode, BehaviorResult, Context};
 
 struct PrintNode;
 

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -234,7 +234,7 @@ impl<'src> TreeDef<'src> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum BlackboardValue<'src> {
-    /// Literal value could have decoded, so it is an owned string.
+    /// Literal value could have been decoded, so it is an owned string.
     Literal(String),
     Ref(&'src str),
 }

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -25,10 +25,18 @@ impl<'src> NodeDef<'src> {
             ports: Vec::new(),
         }
     }
+
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn ports(&self) -> &[PortDef<'src>] {
+        &self.ports
+    }
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct PortDef<'src> {
+pub struct PortDef<'src> {
     pub direction: PortType,
     pub name: &'src str,
     pub ty: Option<&'src str>,
@@ -117,6 +125,20 @@ pub struct TreeDef<'src> {
     pub(crate) port_maps: Vec<PortMap<'src>>,
     pub(crate) children: Vec<TreeDef<'src>>,
     pub(crate) vars: Vec<VarDef<'src>>,
+}
+
+impl<'src> TreeDef<'src> {
+    pub fn get_type(&self) -> &str {
+        self.ty
+    }
+
+    pub fn port_maps(&self) -> &[PortMap<'src>] {
+        &self.port_maps
+    }
+
+    pub fn children(&self) -> &[TreeDef<'src>] {
+        &self.children
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -246,6 +268,20 @@ pub struct PortMap<'src> {
     pub(crate) blackboard_value: BlackboardValue<'src>,
 }
 
+impl<'src> PortMap<'src> {
+    pub fn get_type(&self) -> PortType {
+        self.ty
+    }
+
+    pub fn node_port(&self) -> &'src str {
+        self.node_port
+    }
+
+    pub fn blackboard_value(&self) -> &BlackboardValue<'src> {
+        &self.blackboard_value
+    }
+}
+
 fn subtree_ports_def(i: &str) -> IResult<&str, Vec<PortDef>> {
     let (i, ports) = delimited(
         open_paren,
@@ -260,6 +296,20 @@ pub struct TreeRootDef<'src> {
     pub(crate) name: &'src str,
     pub(crate) root: TreeDef<'src>,
     pub(crate) ports: Vec<PortDef<'src>>,
+}
+
+impl<'src> TreeRootDef<'src> {
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    pub fn root(&self) -> &TreeDef<'src> {
+        &self.root
+    }
+
+    pub fn ports(&self) -> &[PortDef<'src>] {
+        &self.ports
+    }
 }
 
 fn parse_tree(i: &str) -> IResult<&str, TreeRootDef> {

--- a/src/parser/yaml_parser.rs
+++ b/src/parser/yaml_parser.rs
@@ -26,7 +26,7 @@ fn recurse_parse(value: &serde_yaml::Value, reg: &Registry) -> ParseResult {
     if let Some(Value::Sequence(children)) = value.get(&Value::from("children")) {
         for child in children {
             if let Some(built_child) = recurse_parse(child, reg)? {
-                if NumChildren::Finite(child_nodes.len()) < node.num_children() {
+                if NumChildren::Finite(child_nodes.len()) < node.max_children() {
                     child_nodes.push(built_child)
                 } else {
                     return Err(LoadYamlError::AddChildError(AddChildError::TooManyNodes));

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 static SYMBOL_HEAP: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 
 /// An interned string with O(1) equality.
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[derive(Clone, Copy, Eq, Hash)]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,10 @@
 // use std::convert::From;
 use behavior_tree_lite::{
-    hash_map, BehaviorCallback, BehaviorNode, BehaviorResult, Context, FallbackNode, SequenceNode,
-    Symbol,
+    BehaviorCallback, BehaviorNode, BehaviorNodeContainer, BehaviorResult, Context, FallbackNode,
+    SequenceNode, Symbol,
 };
+
+type BNContainer = BehaviorNodeContainer;
 
 struct CheckMeNode;
 
@@ -39,14 +41,14 @@ impl BehaviorNode for AlwaysFail {
 
 #[test]
 fn test_sequence() {
-    let mut seq = SequenceNode::default();
-    seq.add_child(Box::new(AlwaysSucceed), hash_map!()).unwrap();
-    seq.add_child(Box::new(AlwaysSucceed), hash_map!()).unwrap();
+    let mut seq = BNContainer::new_node(SequenceNode::default());
+    seq.add_child(BNContainer::new_node(AlwaysSucceed)).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysSucceed)).unwrap();
     assert_eq!(
         seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Success
     );
-    seq.add_child(Box::new(AlwaysFail), hash_map!()).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysFail)).unwrap();
     assert_eq!(
         seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Fail
@@ -55,14 +57,14 @@ fn test_sequence() {
 
 #[test]
 fn test_fallback() {
-    let mut seq = FallbackNode::default();
-    seq.add_child(Box::new(AlwaysFail), hash_map!()).unwrap();
-    seq.add_child(Box::new(AlwaysFail), hash_map!()).unwrap();
+    let mut seq = BNContainer::new_node(FallbackNode::default());
+    seq.add_child(BNContainer::new_node(AlwaysFail)).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysFail)).unwrap();
     assert_eq!(
         seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Fail
     );
-    seq.add_child(Box::new(AlwaysSucceed), hash_map!()).unwrap();
+    seq.add_child(BNContainer::new_node(AlwaysSucceed)).unwrap();
     assert_eq!(
         seq.tick(&mut |_| None, &mut Context::default()),
         BehaviorResult::Success


### PR DESCRIPTION
⚠️ We have an API breaking change! We will bump the major version after this PR! ⚠️ 

# The issue

We have been using `add_child` method in `BehaviorNode` trait. It means the node implementor is responsible of keeping the child nodes in their fields.
For example, the simplest case is `InverterNode`. It has only one child node so it was implemented as a tuple struct.

```rust
pub struct InverterNode(Option<BehaviorNodeContainer>);
```

and the implementation of `add_child` method looked like this:

```rust
impl BehaviorNode for InverterNode {
    // ...
    fn add_child(&mut self, node: Box<dyn BehaviorNode>, blackboard_map: BBMap) -> AddChildResult {
        if self.0.is_none() {
            self.0 = Some(BehaviorNodeContainer {
                node,
                blackboard_map,
            });
            Ok(())
        } else {
            Err(AddChildError::TooManyNodes)
        }
    }
}
```

There are few issues with this design.
First, it puts the burden of managing the child nodes to the node implementor, but it should be managed by the library.
If the node is one of standard nodes, like this `InverterNode`, that are provided by the library, it would be ok, but we allow the user of this library to implement their own nodes with potential child nodes. Every implementor of `BehaviorNode` with children has to repeat this boilerplate code.

Also, because we manage the blackboard mapping table in a node, we need to swap it temporarily for the child node before ticking, and restore after.

```rust
impl BehaviorNode for InverterNode {
    fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
        // ...
            std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
            let res = match node.node.tick(arg, ctx) {
                // ...
            };
            std::mem::swap(&mut ctx.blackboard_map, &mut node.blackboard_map);
            res
        // ...
    }
}
```

This is another very boilerplatey-code and prone to errors. I myself forgot to restore the blackboard mapping in the standard nodes multiple times.

Ok, boilerplate can be reduced by a macro, but there is a bigger issue.
This structure makes reflection impossible, because the library doesn't know if any node has children. All it has is a `Box` of root behavior node. The rest of the information is erased by trait object.
Technically, we could add another method, such as `get_children()`, to allow inspection, but it would put even more burden to the implementor to make sure that it works consistently with `add_child`. And there would be no mechanism to ensure they are correct.

We would like to implement a visual editor or debugger, which requires inspection of child nodes.


# The new design

We replace the `add_child` trait method with `max_children`. It returns the number of allowed child nodes.

```rust
pub trait BehaviorNode {
    // ...
    fn max_children(&self) -> NumChildren {
        NumChildren::Finite(0)
    }
}
```

The returned value is a `NumChildren` enum, which is either `Finite(n)` or `Infinite`.

```rust
enum NumChildren {
    Finite(usize),
    Infinite,
}
```

Technically, `Infinite` is not necessary, since you cannot allocate child nodes more than `usize::MAX`. But it is more intuitive to just return `NumChildren::Infinite` to indicate that you allow any number of children.
The default implementation of `max_children` is `Finite(0)`, which means it does not allow any child nodes.

Once the node implements `max_children`, the library takes care of child nodes management.
Namely, the child nodes are put in `BehaviorNodeContainer`.

```rust
pub struct BehaviorNodeContainer {
    pub(crate) node: Box<dyn BehaviorNode>,
    pub(crate) blackboard_map: HashMap<Symbol, BlackboardValue>,
    pub(crate) child_nodes: Vec<BehaviorNodeContainer>,
}
```

In this way, the library can keep track of tree structure and ensure the structure is consistent.

One issue with the new design is that you cannot call `tick` of child nodes so easily anymore, because it is not a direct field of `self`.
So we make the `Context` to manage the child nodes of the currently running node and provide `Context::tick_child()` method for the node.

`tick_child` is a method defined like below. It takes an index of the child nodes and the callback.
It will return `None` if the index is out of bound, or return the result in `Some` if it has a valid child node.

```rust
impl Context {
    pub fn tick_child(&mut self, idx: usize, arg: BehaviorCallback) -> Option<BehaviorResult>;
}
```

It also takes care of swapping blackboard variables mapping, so you do not need to implement it in your custom behavior node.

Now, the whole `InverterNode` became much simpler.

```rust
impl BehaviorNode for InverterNode {
    fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
        match ctx.tick_child(0, arg) {
            // ...
        }
    }

    fn max_children(&self) -> NumChildren {
        NumChildren::Finite(1)
    }
}
```

# The changes to the API

To the end user, there are 2 API changes involved.
The first is the construction of a behavior node. You need `BehaviorNodeContainer` for a valid behavior tree. `BehaviorNodeContainer` provides a constructor `new_node` which can take any `impl BehaviorNode` for conveinence, so you can construct a tree like below.

```rust
let mut root = BehaviorNodeContainer::new_node(SequenceNode::default());
root.add_child(BehaviorNodeContainer::new_node(PrintBodyNode));
```

`add_child` is now a method of `BehaviorNodeContainer`, so you can think of it as `BehaviorNode` trait object in previous version.

The second change is the implementation of custom nodes with children. As noted above, `add_child` method for `BehaviorNode` was removed, and there is `max_children` instead.
Also you need to use `ctx.tick_child()` when you want to call tick method on the child. And the context manages the number of child nodes, so it has a method `num_children()` to return it.

Typical behavior node implementation would look like this (I pick `ReactiveSequenceNode` since it is the simplest node with multiple child nodes):

```rust
#[derive(Default)]
pub struct ReactiveSequenceNode;

impl BehaviorNode for ReactiveSequenceNode {
    fn tick(&mut self, arg: BehaviorCallback, ctx: &mut Context) -> BehaviorResult {
        for i in 0..ctx.num_children() {
            match ctx.tick_child(i, arg) {
                Some(BehaviorResult::Fail) => {
                    return BehaviorResult::Fail;
                }
                Some(BehaviorResult::Running) => {
                    return BehaviorResult::Running;
                }
                _ => (),
            }
        }
        BehaviorResult::Success
    }

    fn max_children(&self) -> NumChildren {
        NumChildren::Infinite
    }
}
```

In general, these changes should make writing custom behavior nodes easier.

There is no change to the BTC file format.
