### PR TITLE
Enable inspection of running tree from outside crate

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -103,21 +103,19 @@ impl BehaviorNodeContainer {
         &self.blackboard_map
     }
 
-    pub fn port_map<'a>(&'a self) -> impl Iterator<Item = PortMapOwned> {
+    pub fn port_map(&self) -> impl Iterator<Item = PortMapOwned> {
         let items = self
             .node
             .provided_ports()
             .into_iter()
             .filter_map(|port| {
-                if let Some(mapped) = self.blackboard_map.get(&port.key) {
-                    Some(PortMapOwned::new(
+                self.blackboard_map.get(&port.key).map(|mapped| {
+                    PortMapOwned::new(
                         port.ty,
                         port.key.to_string(),
-                        BlackboardValue::to_owned2(&mapped),
-                    ))
-                } else {
-                    None
-                }
+                        BlackboardValue::to_owned2(mapped),
+                    )
+                })
             })
             .collect::<Vec<_>>();
         items.into_iter()

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, cell::Cell};
+use std::{cell::Cell, collections::HashMap};
 
 use crate::{
     error::{AddChildError, AddChildResult},
-    BehaviorCallback, BehaviorNode, BehaviorResult, BlackboardValue, Context, NumChildren, Symbol, PortSpec, parser::PortMapOwned,
+    parser::PortMapOwned,
+    BehaviorCallback, BehaviorNode, BehaviorResult, BlackboardValue, Context, NumChildren, Symbol,
 };
 
 pub struct BehaviorNodeContainer {
@@ -103,15 +104,22 @@ impl BehaviorNodeContainer {
     }
 
     pub fn port_map<'a>(&'a self) -> impl Iterator<Item = PortMapOwned> {
-        let items = self.node.provided_ports().into_iter().filter_map(|port| {
-            if let Some(mapped) = self.blackboard_map.get(&port.key) {
-                Some(PortMapOwned::new(port.ty,
-                    port.key.to_string(), BlackboardValue::to_owned2(&mapped)
-                ))
-            } else {
-                None
-            }
-        }).collect::<Vec<_>>();
+        let items = self
+            .node
+            .provided_ports()
+            .into_iter()
+            .filter_map(|port| {
+                if let Some(mapped) = self.blackboard_map.get(&port.key) {
+                    Some(PortMapOwned::new(
+                        port.ty,
+                        port.key.to_string(),
+                        BlackboardValue::to_owned2(&mapped),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
         items.into_iter()
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, cell::Cell};
 
 use crate::{
     error::{AddChildError, AddChildResult},
@@ -12,6 +12,8 @@ pub struct BehaviorNodeContainer {
     pub(crate) blackboard_map: HashMap<Symbol, BlackboardValue>,
     pub(crate) child_nodes: Vec<BehaviorNodeContainer>,
     pub(crate) last_result: Option<BehaviorResult>,
+    pub(crate) is_subtree: bool,
+    pub(crate) subtree_expanded: Cell<bool>,
 }
 
 impl BehaviorNodeContainer {
@@ -25,6 +27,8 @@ impl BehaviorNodeContainer {
             blackboard_map,
             child_nodes: vec![],
             last_result: None,
+            is_subtree: false,
+            subtree_expanded: Cell::new(false),
         }
     }
 
@@ -35,6 +39,8 @@ impl BehaviorNodeContainer {
             blackboard_map: HashMap::new(),
             child_nodes: vec![],
             last_result: None,
+            is_subtree: false,
+            subtree_expanded: Cell::new(false),
         }
     }
 
@@ -45,6 +51,8 @@ impl BehaviorNodeContainer {
             blackboard_map: HashMap::new(),
             child_nodes: vec![],
             last_result: None,
+            is_subtree: false,
+            subtree_expanded: Cell::new(false),
         }
     }
 
@@ -55,6 +63,8 @@ impl BehaviorNodeContainer {
             blackboard_map: HashMap::new(),
             child_nodes: vec![],
             last_result: None,
+            is_subtree: false,
+            subtree_expanded: Cell::new(false),
         }
     }
 
@@ -103,5 +113,17 @@ impl BehaviorNodeContainer {
             }
         }).collect::<Vec<_>>();
         items.into_iter()
+    }
+
+    pub fn is_subtree(&self) -> bool {
+        self.is_subtree
+    }
+
+    pub fn is_subtree_expanded(&self) -> bool {
+        self.subtree_expanded.get()
+    }
+
+    pub fn expand_subtree(&self, b: bool) {
+        self.subtree_expanded.set(b);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -58,7 +58,11 @@ impl Context {
     pub fn tick_child(&mut self, idx: usize, arg: BehaviorCallback) -> Option<BehaviorResult> {
         // Take the children temporarily because the context's `child_nodes` will be used by the child node (for grandchildren)
         let mut children = std::mem::take(&mut self.child_nodes.0);
-        let res = children.get_mut(idx).map(|child| child.tick(arg, self));
+        let res = children.get_mut(idx).map(|child| {
+            let res = child.tick(arg, self);
+            child.last_result = Some(res);
+            res
+        });
         self.child_nodes.0 = children;
         res
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@ pub use crate::nodes::{tick_child_node, FallbackNode, SequenceNode};
 pub use crate::symbol::Symbol;
 pub use crate::{
     parser::{load, load_yaml, node_def, parse_file, parse_nodes, NodeDef},
-    port::{PortSpec, PortType},
+    port::{PortSpec, PortType, AbstractPortMap, BlackboardValueOwned},
     registry::{boxify, Constructor, Registry},
 };
 pub use ::once_cell::sync::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@ pub use crate::nodes::{tick_child_node, FallbackNode, SequenceNode};
 pub use crate::symbol::Symbol;
 pub use crate::{
     parser::{load, load_yaml, node_def, parse_file, parse_nodes, NodeDef},
-    port::{PortSpec, PortType, AbstractPortMap, BlackboardValueOwned},
+    port::{AbstractPortMap, BlackboardValueOwned, PortSpec, PortType},
     registry::{boxify, Constructor, Registry},
 };
 pub use ::once_cell::sync::*;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,6 @@ mod yaml_parser;
 
 pub use self::{
     loader::load,
-    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef, PortMap, PortMapOwned},
+    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef, PortMap, PortMapOwned, TreeSource},
     yaml_parser::load_yaml,
 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,6 @@ mod yaml_parser;
 
 pub use self::{
     loader::load,
-    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef},
+    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef, PortMap, PortMapOwned},
     yaml_parser::load_yaml,
 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,9 @@ mod yaml_parser;
 
 pub use self::{
     loader::load,
-    nom_parser::{node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, TreeDef, PortMap, PortMapOwned, TreeSource},
+    nom_parser::{
+        node_def, parse_file, parse_nodes, BlackboardValue, NodeDef, PortMap, PortMapOwned,
+        TreeDef, TreeSource,
+    },
     yaml_parser::load_yaml,
 };

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -96,11 +96,7 @@ fn load_recurse(
     vars: &mut HashSet<Symbol>,
 ) -> Result<BehaviorNodeContainer, LoadError> {
     let mut ret = if let Some(ret) = registry.build(parent.ty) {
-        BehaviorNodeContainer {
-            node: ret,
-            blackboard_map: HashMap::new(),
-            child_nodes: vec![],
-        }
+        BehaviorNodeContainer::new_raw_with_name(ret, parent.ty.to_string())
     } else {
         let tree = tree_source
             .tree_defs
@@ -132,6 +128,7 @@ fn load_recurse(
             &mut vars,
         )?;
         BehaviorNodeContainer {
+            name: parent.ty.to_owned(),
             node: Box::new(SubtreeNode::new(
                 HashMap::new(),
                 tree.ports
@@ -144,6 +141,7 @@ fn load_recurse(
             )),
             blackboard_map: HashMap::new(),
             child_nodes: vec![loaded_subtree],
+            last_result: None,
         }
     };
 

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -128,7 +128,7 @@ fn load_recurse(
             &mut vars,
         )?;
         BehaviorNodeContainer {
-            name: parent.ty.to_owned(),
+            name: "Subtree".to_owned(),
             node: Box::new(SubtreeNode::new(
                 HashMap::new(),
                 tree.ports
@@ -142,6 +142,8 @@ fn load_recurse(
             blackboard_map: HashMap::new(),
             child_nodes: vec![loaded_subtree],
             last_result: None,
+            is_subtree: true,
+            subtree_expanded: std::cell::Cell::new(false),
         }
     };
 

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -10,7 +10,7 @@ use nom::{
     Finish, IResult,
 };
 
-use crate::{PortType, BlackboardValueOwned, AbstractPortMap};
+use crate::{BlackboardValueOwned, PortType};
 
 #[derive(Debug, PartialEq)]
 pub struct NodeDef<'src> {
@@ -311,7 +311,7 @@ impl PortMapOwned {
         Self {
             ty,
             node_port,
-            blackboard_value
+            blackboard_value,
         }
     }
 }

--- a/src/parser/nom_parser.rs
+++ b/src/parser/nom_parser.rs
@@ -10,7 +10,7 @@ use nom::{
     Finish, IResult,
 };
 
-use crate::PortType;
+use crate::{PortType, BlackboardValueOwned, AbstractPortMap};
 
 #[derive(Debug, PartialEq)]
 pub struct NodeDef<'src> {
@@ -261,6 +261,15 @@ pub enum BlackboardValue<'src> {
     Ref(&'src str),
 }
 
+impl<'src> BlackboardValue<'src> {
+    fn to_owned(&self) -> BlackboardValueOwned {
+        match self {
+            Self::Literal(s) => BlackboardValueOwned::Literal(s.clone()),
+            Self::Ref(s) => BlackboardValueOwned::Ref(s.to_string()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct PortMap<'src> {
     pub(crate) ty: PortType,
@@ -279,6 +288,31 @@ impl<'src> PortMap<'src> {
 
     pub fn blackboard_value(&self) -> &BlackboardValue<'src> {
         &self.blackboard_value
+    }
+
+    pub fn to_owned(&self) -> PortMapOwned {
+        PortMapOwned {
+            ty: self.ty,
+            node_port: self.node_port.to_owned(),
+            blackboard_value: self.blackboard_value.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PortMapOwned {
+    pub(crate) ty: PortType,
+    pub(crate) node_port: String,
+    pub(crate) blackboard_value: BlackboardValueOwned,
+}
+
+impl PortMapOwned {
+    pub fn new(ty: PortType, node_port: String, blackboard_value: BlackboardValueOwned) -> Self {
+        Self {
+            ty,
+            node_port,
+            blackboard_value
+        }
     }
 }
 

--- a/src/parser/yaml_parser.rs
+++ b/src/parser/yaml_parser.rs
@@ -57,6 +57,8 @@ fn recurse_parse(value: &serde_yaml::Value, reg: &Registry) -> ParseResult {
         blackboard_map,
         child_nodes,
         last_result: None,
+        is_subtree: false,
+        subtree_expanded: std::cell::Cell::new(false),
     }))
 }
 

--- a/src/parser/yaml_parser.rs
+++ b/src/parser/yaml_parser.rs
@@ -8,14 +8,14 @@ use std::collections::HashMap;
 type ParseResult = Result<Option<BehaviorNodeContainer>, LoadYamlError>;
 
 fn recurse_parse(value: &serde_yaml::Value, reg: &Registry) -> ParseResult {
-    let node = if let Some(node) =
-        value
-            .get("type")
-            .and_then(|value| value.as_str())
-            .and_then(|value| {
-                eprintln!("Returning {value}");
-                reg.build(value)
-            }) {
+    let Some(name) = value.get("type").and_then(|value| value.as_str()) else {
+        return Ok(None);
+    };
+
+    let node = if let Some(node) = {
+        eprintln!("Returning {name}");
+        reg.build(name)
+    } {
         node
     } else {
         eprintln!("Type does not exist in value {value:?}");
@@ -52,9 +52,11 @@ fn recurse_parse(value: &serde_yaml::Value, reg: &Registry) -> ParseResult {
     };
 
     Ok(Some(BehaviorNodeContainer {
+        name: name.to_owned(),
         node,
         blackboard_map,
         child_nodes,
+        last_result: None,
     }))
 }
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,4 +1,7 @@
-use crate::{Symbol, parser::{PortMap, BlackboardValue, PortMapOwned}, Blackboard};
+use crate::{
+    parser::{BlackboardValue, PortMap, PortMapOwned},
+    Symbol,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PortType {
@@ -47,7 +50,7 @@ impl crate::BlackboardValue {
     pub fn to_owned2(&self) -> BlackboardValueOwned {
         match self {
             Self::Literal(s) => BlackboardValueOwned::Literal(s.clone()),
-            Self::Ref(s, _) => BlackboardValueOwned::Ref(s.to_string())
+            Self::Ref(s, _) => BlackboardValueOwned::Ref(s.to_string()),
         }
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,4 +1,4 @@
-use crate::Symbol;
+use crate::{Symbol, parser::{PortMap, BlackboardValue, PortMapOwned}, Blackboard};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PortType {
@@ -33,5 +33,58 @@ impl PortSpec {
             ty: PortType::InOut,
             key: key.into(),
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum BlackboardValueOwned {
+    /// Literal value could have been decoded, so it is an owned string.
+    Literal(String),
+    Ref(String),
+}
+
+impl crate::BlackboardValue {
+    pub fn to_owned2(&self) -> BlackboardValueOwned {
+        match self {
+            Self::Literal(s) => BlackboardValueOwned::Literal(s.clone()),
+            Self::Ref(s, _) => BlackboardValueOwned::Ref(s.to_string())
+        }
+    }
+}
+
+pub trait AbstractPortMap<'src> {
+    fn get_type(&self) -> PortType;
+    fn node_port(&self) -> &str;
+    fn blackboard_value(&self) -> BlackboardValueOwned;
+}
+
+impl<'src> AbstractPortMap<'src> for PortMap<'src> {
+    fn get_type(&self) -> PortType {
+        self.ty
+    }
+
+    fn node_port(&self) -> &'src str {
+        self.node_port
+    }
+
+    fn blackboard_value(&self) -> BlackboardValueOwned {
+        match &self.blackboard_value {
+            BlackboardValue::Literal(s) => BlackboardValueOwned::Literal(s.clone()),
+            BlackboardValue::Ref(s) => BlackboardValueOwned::Ref(s.to_string()),
+        }
+    }
+}
+
+impl<'src> AbstractPortMap<'src> for PortMapOwned {
+    fn get_type(&self) -> PortType {
+        self.ty
+    }
+
+    fn node_port(&self) -> &str {
+        &self.node_port
+    }
+
+    fn blackboard_value(&self) -> BlackboardValueOwned {
+        self.blackboard_value.clone()
     }
 }


### PR DESCRIPTION
A small change to enable inspection of nodes, enabling visual inspection of running behavior tree, like demonstrated in [swarm-rs](https://github.com/msakuta/swarm-rs).

![image](https://user-images.githubusercontent.com/2798715/232280530-dea87338-71f9-4802-a751-21d3ff01474c.png)
