### PR TITLE
Fix variable reference did not have IsTrue node name

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -99,6 +99,11 @@ impl BehaviorNodeContainer {
         &self.name
     }
 
+    pub(crate) fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
+    }
+
     pub fn blackboard_map(&self) -> &HashMap<Symbol, BlackboardValue> {
         &self.blackboard_map
     }

--- a/src/parser/loader.rs
+++ b/src/parser/loader.rs
@@ -160,7 +160,10 @@ fn load_recurse(
                     *INPUT,
                     crate::BlackboardValue::Ref(child.ty.into(), PortType::Input),
                 );
-                Some(BehaviorNodeContainer::new(Box::new(IsTrueNode), bbmap))
+                Some(
+                    BehaviorNodeContainer::new(Box::new(IsTrueNode), bbmap)
+                        .with_name("IsTrue".to_owned()),
+                )
             } else {
                 None
             }


### PR DESCRIPTION
Behavior tree config file format supports variable references, which translates to `IsTrue` node. For example, btc file fragment like this:

```
    var fight = false
    var fighter = false
   ...
    if (fight || fighter) {
```

is a syntax suger for this:

```
    if (Fallback {
        IsTrue (input <- "fight")
        IsTrue (input <- "figheter")
    }) {
```

However, BehaviorTreeContainer's name field was not initialized for injected `IsTrue` nodes, so it is an empty string.
In [swarm-rs](https://github.com/msakuta/swarm-rs/security)'s visualization, it appears as empty node:

![image](https://user-images.githubusercontent.com/2798715/233830937-0452f01b-f690-4126-9f18-c1d7e566d841.png)

After fix:

![image](https://user-images.githubusercontent.com/2798715/233831221-f6be3771-3cb1-4616-89bc-e5a121cee766.png)

